### PR TITLE
chore: CloseDB() refactor

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,7 +47,7 @@ func run(logger *slog.Logger, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
-	defer repo.CloseDB()
+	defer repo.Close()
 
 	rCache, err := cache.NewRedis(ctx, cfg.Redis)
 	if err != nil {

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -56,8 +56,6 @@ func (m mockRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return m.delete(ctx, id)
 }
 
-func (m mockRepo) CloseDB() {}
-
 type mockCache struct{}
 
 func (m *mockCache) Set(_ context.Context, _ string, _ entity.Product) error {

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -43,7 +43,7 @@ func (pg *Repository) Ping(ctx context.Context) error {
 	return pg.db.PingContext(ctx)
 }
 
-func (pg *Repository) CloseDB() {
+func (pg *Repository) Close() {
 	if err := pg.db.Close(); err != nil {
 		pg.logger.Error("failed to close db connection", slog.Any("error", err))
 	}

--- a/internal/repository/postgres_test.go
+++ b/internal/repository/postgres_test.go
@@ -83,7 +83,7 @@ func setupTestContainerDB(t *testing.T) (*Repository, func()) {
 	}
 
 	cleanup := func() {
-		repo.CloseDB()
+		repo.Close()
 		if err := pgContainer.Terminate(context.Background()); err != nil {
 			t.Fatalf("failed to terminate pg container: %v", err)
 		}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -34,7 +34,6 @@ type MockRepository struct {
 	FindAllFn  func(ctx context.Context, limit, offset int) ([]entity.Product, error)
 	UpdateFn   func(ctx context.Context, p entity.Product) error
 	DeleteFn   func(ctx context.Context, id uuid.UUID) error
-	CloseDBFn  func()
 }
 
 func (m *MockRepository) Save(ctx context.Context, p entity.Product) (entity.Product, error) {
@@ -61,12 +60,6 @@ func (m *MockRepository) Delete(ctx context.Context, id uuid.UUID) error {
 		return m.DeleteFn(ctx, id)
 	}
 	return nil
-}
-
-func (m *MockRepository) CloseDB() {
-	if m.CloseDBFn != nil {
-		m.CloseDBFn()
-	}
 }
 
 func TestService_Create(t *testing.T) {


### PR DESCRIPTION
- remove redundant CloseDB methods from test mocks
- rename Repository.CloseDB to Close