### PR TITLE
feat: keyset pagination for GET /product

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@ curl -s -X POST http://localhost:7000/product \
 
 # get a product by id
 curl -s http://localhost:7000/product/{id}
+
+# list products (keyset pagination)
+curl -s 'http://localhost:7000/product?limit=10'
+# next page: pass the nextCursor from the previous response
+curl -s 'http://localhost:7000/product?limit=10&cursor={nextCursor}'
 ```
+
+The list endpoint returns `{"items":[...],"nextCursor":"<id>"}`; a missing `nextCursor` means the last page.
 
 See `api.rest` for the full set of example requests.
 

--- a/api.rest
+++ b/api.rest
@@ -26,8 +26,9 @@ GET {{baseUrl}}/product/{{prodID}}
 ### LIST PRODUCTS
 GET {{baseUrl}}/product
 
-### LIST PRODUCTS (paginated)
-GET {{baseUrl}}/product?limit=10&offset=0
+### LIST PRODUCTS (keyset paginated)
+# next page: copy `nextCursor` from the response into the cursor query param
+GET {{baseUrl}}/product?limit=10&cursor=
 
 ### UPDATE PRODUCT
 PUT {{baseUrl}}/product/{{prodID}}

--- a/internal/entity/product.go
+++ b/internal/entity/product.go
@@ -16,6 +16,12 @@ type Product struct {
 	Price Money
 }
 
+// ProductPage is a single keyset page
+type ProductPage struct {
+	Items   []Product
+	HasMore bool
+}
+
 // Validate ensures the product meets basic business rules before processing
 func (p *Product) Validate() error {
 	if p.Name == "" {

--- a/internal/httpapi/dto.go
+++ b/internal/httpapi/dto.go
@@ -5,16 +5,21 @@ import (
 	"github.com/google/uuid"
 )
 
-type productResponse struct {
-	ID    uuid.UUID `json:"id"`
-	Name  string    `json:"name"`
-	Price moneyDTO  `json:"price"`
-}
-
-type moneyDTO struct {
-	MinorAmount int64           `json:"minorAmount"`
-	Currency    entity.Currency `json:"currency"`
-}
+type (
+	productResponse struct {
+		ID    uuid.UUID `json:"id"`
+		Name  string    `json:"name"`
+		Price moneyDTO  `json:"price"`
+	}
+	moneyDTO struct {
+		MinorAmount int64           `json:"minorAmount"`
+		Currency    entity.Currency `json:"currency"`
+	}
+	productsPage struct {
+		Items      []productResponse `json:"items"`
+		NextCursor string            `json:"nextCursor,omitempty"`
+	}
+)
 
 func toProductResponse(p entity.Product) productResponse {
 	return productResponse{ID: p.ID, Name: p.Name, Price: toMoneyDTO(p.Price)}
@@ -26,6 +31,20 @@ func toProductsResponse(ps []entity.Product) []productResponse {
 		out[i] = toProductResponse(p)
 	}
 	return out
+}
+
+func toProductsPage(page entity.ProductPage) productsPage {
+	return productsPage{
+		Items:      toProductsResponse(page.Items),
+		NextCursor: nextCursor(page),
+	}
+}
+
+func nextCursor(page entity.ProductPage) string {
+	if !page.HasMore || len(page.Items) == 0 {
+		return ""
+	}
+	return page.Items[len(page.Items)-1].ID.String()
 }
 
 func toMoney(in moneyInput) entity.Money {

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -22,7 +22,7 @@ type (
 	processor interface {
 		Create(context.Context, entity.Product) (entity.Product, error)
 		FindByID(context.Context, uuid.UUID) (entity.Product, error)
-		FindAll(ctx context.Context, limit, offset int) ([]entity.Product, error)
+		FindAll(context.Context, uuid.NullUUID, int) (entity.ProductPage, error)
 		Update(context.Context, entity.Product) error
 		Delete(context.Context, uuid.UUID) error
 	}
@@ -85,7 +85,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	offset, err := parseOffset(q.Get("offset"))
+	cursor, err := parseCursor(q.Get("cursor"))
 	if err != nil {
 		respondError(w, http.StatusBadRequest, err.Error())
 		return
@@ -94,12 +94,12 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
 	defer cancel()
 
-	products, err := h.processor.FindAll(ctx, limit, offset)
+	page, err := h.processor.FindAll(ctx, cursor, limit)
 	if err != nil {
 		h.internalError(w, "failed to find all products", slog.Any("error", err))
 		return
 	}
-	respond(w, http.StatusOK, toProductsResponse(products))
+	respond(w, http.StatusOK, toProductsPage(page))
 }
 
 func (h *Handler) Add(w http.ResponseWriter, r *http.Request) {
@@ -216,13 +216,13 @@ func parseLimit(raw string) (int, error) {
 	return min(n, maxLimit), nil
 }
 
-func parseOffset(raw string) (int, error) {
+func parseCursor(raw string) (uuid.NullUUID, error) {
 	if raw == "" {
-		return 0, nil
+		return uuid.NullUUID{}, nil
 	}
-	n, err := strconv.Atoi(raw)
+	id, err := uuid.Parse(raw)
 	if err != nil {
-		return 0, fmt.Errorf("invalid offset: %q", raw)
+		return uuid.NullUUID{}, fmt.Errorf("invalid cursor: %q", raw)
 	}
-	return max(n, 0), nil
+	return uuid.NullUUID{UUID: id, Valid: true}, nil
 }

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -22,8 +22,8 @@ var testHTTPConfig = config.HTTP{
 	CompressMinBytes: 1024,
 }
 
-func testMoney(amount int64) entity.Money {
-	return entity.Money{MinorAmount: amount, Currency: entity.CurrencyPLN}
+func testMoney() entity.Money {
+	return entity.Money{MinorAmount: 123, Currency: entity.CurrencyPLN}
 }
 
 func testMoneyInput(amount int64) moneyInput {
@@ -44,11 +44,11 @@ func decodeJSON[T any](t *testing.T, r io.Reader) T {
 }
 
 type mockProcessor struct {
-	create   func(ctx context.Context, p entity.Product) (entity.Product, error)
-	findByID func(ctx context.Context, id uuid.UUID) (entity.Product, error)
-	findAll  func(ctx context.Context, limit, offset int) ([]entity.Product, error)
-	update   func(ctx context.Context, p entity.Product) error
-	delete   func(ctx context.Context, id uuid.UUID) error
+	create   func(context.Context, entity.Product) (entity.Product, error)
+	findByID func(context.Context, uuid.UUID) (entity.Product, error)
+	findAll  func(context.Context, uuid.NullUUID, int) (entity.ProductPage, error)
+	update   func(context.Context, entity.Product) error
+	delete   func(context.Context, uuid.UUID) error
 }
 
 func (m *mockProcessor) Create(ctx context.Context, p entity.Product) (entity.Product, error) {
@@ -62,8 +62,9 @@ func (m *mockProcessor) FindByID(ctx context.Context, id uuid.UUID) (entity.Prod
 	return m.findByID(ctx, id)
 }
 
-func (m *mockProcessor) FindAll(ctx context.Context, limit, offset int) ([]entity.Product, error) {
-	return m.findAll(ctx, limit, offset)
+func (m *mockProcessor) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
+) (entity.ProductPage, error) {
+	return m.findAll(ctx, cursor, limit)
 }
 
 func (m *mockProcessor) Update(ctx context.Context, p entity.Product) error {
@@ -98,7 +99,7 @@ func TestGetProductByID(t *testing.T) {
 			id:   uuid.Must(uuid.NewV7()).String(),
 			setupMock: func() {
 				proc.findByID = func(_ context.Context, id uuid.UUID) (entity.Product, error) {
-					return entity.Product{ID: id, Name: "Car", Price: testMoney(123)}, nil
+					return entity.Product{ID: id, Name: "Car", Price: testMoney()}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
@@ -158,6 +159,9 @@ func TestGetProductByID(t *testing.T) {
 func TestGetProducts(t *testing.T) {
 	mux, proc := setupTest(t, testHTTPConfig)
 
+	cursorID := uuid.Must(uuid.NewV7())
+	lastID := uuid.Must(uuid.NewV7())
+
 	tests := []struct {
 		name           string
 		url            string
@@ -165,12 +169,13 @@ func TestGetProducts(t *testing.T) {
 		expectedStatus int
 		expectedMsg    string
 		expectedNames  []string
+		wantNextCursor string
 	}{
 		{
 			name: "empty",
 			setupMock: func() {
-				proc.findAll = func(_ context.Context, _, _ int) ([]entity.Product, error) {
-					return nil, nil
+				proc.findAll = func(_ context.Context, _ uuid.NullUUID, _ int) (entity.ProductPage, error) {
+					return entity.ProductPage{}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
@@ -179,25 +184,25 @@ func TestGetProducts(t *testing.T) {
 		{
 			name: "success with default pagination",
 			setupMock: func() {
-				proc.findAll = func(_ context.Context, limit, offset int) ([]entity.Product, error) {
-					if limit != 50 || offset != 0 {
-						t.Errorf("got limit=%d offset=%d, want 50/0", limit, offset)
+				proc.findAll = func(_ context.Context, cursor uuid.NullUUID, limit int) (entity.ProductPage, error) {
+					if limit != 50 || cursor.Valid {
+						t.Errorf("got limit=%d cursor=%v, want 50/first-page", limit, cursor)
 					}
-					return []entity.Product{{Name: "Car", Price: testMoney(123)}}, nil
+					return entity.ProductPage{Items: []entity.Product{{Name: "Car", Price: testMoney()}}}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
 			expectedNames:  []string{"Car"},
 		},
 		{
-			name: "explicit limit and offset",
-			url:  "/product?limit=10&offset=5",
+			name: "explicit limit and cursor",
+			url:  "/product?limit=10&cursor=" + cursorID.String(),
 			setupMock: func() {
-				proc.findAll = func(_ context.Context, limit, offset int) ([]entity.Product, error) {
-					if limit != 10 || offset != 5 {
-						t.Errorf("got limit=%d offset=%d, want 10/5", limit, offset)
+				proc.findAll = func(_ context.Context, cursor uuid.NullUUID, limit int) (entity.ProductPage, error) {
+					if limit != 10 || !cursor.Valid || cursor.UUID != cursorID {
+						t.Errorf("got limit=%d cursor=%v, want 10/%s", limit, cursor, cursorID)
 					}
-					return []entity.Product{{Name: "Car", Price: testMoney(123)}}, nil
+					return entity.ProductPage{Items: []entity.Product{{Name: "Car", Price: testMoney()}}}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
@@ -207,11 +212,11 @@ func TestGetProducts(t *testing.T) {
 			name: "limit clamped to max",
 			url:  "/product?limit=500",
 			setupMock: func() {
-				proc.findAll = func(_ context.Context, limit, _ int) ([]entity.Product, error) {
+				proc.findAll = func(_ context.Context, _ uuid.NullUUID, limit int) (entity.ProductPage, error) {
 					if limit != 200 {
 						t.Errorf("got limit=%d, want 200", limit)
 					}
-					return nil, nil
+					return entity.ProductPage{}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
@@ -221,29 +226,29 @@ func TestGetProducts(t *testing.T) {
 			name: "negative limit falls back to default",
 			url:  "/product?limit=-5",
 			setupMock: func() {
-				proc.findAll = func(_ context.Context, limit, _ int) ([]entity.Product, error) {
+				proc.findAll = func(_ context.Context, _ uuid.NullUUID, limit int) (entity.ProductPage, error) {
 					if limit != 50 {
 						t.Errorf("got limit=%d, want 50", limit)
 					}
-					return nil, nil
+					return entity.ProductPage{}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
 			expectedNames:  []string{},
 		},
 		{
-			name: "negative offset clamped to zero",
-			url:  "/product?offset=-1",
+			name: "more pages set next cursor",
 			setupMock: func() {
-				proc.findAll = func(_ context.Context, _, offset int) ([]entity.Product, error) {
-					if offset != 0 {
-						t.Errorf("got offset=%d, want 0", offset)
-					}
-					return nil, nil
+				proc.findAll = func(_ context.Context, _ uuid.NullUUID, _ int) (entity.ProductPage, error) {
+					return entity.ProductPage{
+						Items:   []entity.Product{{ID: lastID, Name: "Car", Price: testMoney()}},
+						HasMore: true,
+					}, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
-			expectedNames:  []string{},
+			expectedNames:  []string{"Car"},
+			wantNextCursor: lastID.String(),
 		},
 		{
 			name:           "invalid limit",
@@ -253,11 +258,11 @@ func TestGetProducts(t *testing.T) {
 			expectedMsg:    "invalid limit: \"abc\"",
 		},
 		{
-			name:           "invalid offset",
-			url:            "/product?offset=xyz",
+			name:           "invalid cursor",
+			url:            "/product?cursor=xyz",
 			setupMock:      func() {},
 			expectedStatus: http.StatusBadRequest,
-			expectedMsg:    "invalid offset: \"xyz\"",
+			expectedMsg:    "invalid cursor: \"xyz\"",
 		},
 	}
 
@@ -283,14 +288,17 @@ func TestGetProducts(t *testing.T) {
 				}
 				return
 			}
-			products := decodeJSON[[]productResponse](t, resp.Body)
-			if len(products) != len(tt.expectedNames) {
-				t.Fatalf("got len %d, want %d", len(products), len(tt.expectedNames))
+			page := decodeJSON[productsPage](t, resp.Body)
+			if len(page.Items) != len(tt.expectedNames) {
+				t.Fatalf("got len %d, want %d", len(page.Items), len(tt.expectedNames))
 			}
 			for i, name := range tt.expectedNames {
-				if products[i].Name != name {
-					t.Errorf("got name %q, want %q", products[i].Name, name)
+				if page.Items[i].Name != name {
+					t.Errorf("got name %q, want %q", page.Items[i].Name, name)
 				}
+			}
+			if page.NextCursor != tt.wantNextCursor {
+				t.Errorf("got nextCursor %q, want %q", page.NextCursor, tt.wantNextCursor)
 			}
 		})
 	}

--- a/internal/httpapi/probes.go
+++ b/internal/httpapi/probes.go
@@ -6,14 +6,16 @@ import (
 	"time"
 )
 
-type pinger interface {
-	Ping(context.Context) error
-}
+type (
+	pinger interface {
+		Ping(context.Context) error
+	}
 
-type InternalHandler struct {
-	db    pinger
-	cache pinger
-}
+	InternalHandler struct {
+		db    pinger
+		cache pinger
+	}
+)
 
 func NewInternalHandler(db pinger, cache pinger) *InternalHandler {
 	return &InternalHandler{db: db, cache: cache}

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -63,7 +63,9 @@ func (pg *Repository) Save(ctx context.Context, p entity.Product) (entity.Produc
 	}
 	defer stmt.Close()
 
-	if _, err := stmt.ExecContext(ctx, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency)); err != nil {
+	if _, err := stmt.ExecContext(
+		ctx, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency),
+	); err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
 			return entity.Product{}, fmt.Errorf("failed to rollback transaction: %w", rollbackErr)
 		}
@@ -91,29 +93,40 @@ func (pg *Repository) FindByID(ctx context.Context, id uuid.UUID) (entity.Produc
 	return p, nil
 }
 
-func (pg *Repository) FindAll(ctx context.Context, limit, offset int) ([]entity.Product, error) {
-	rows, err := pg.db.QueryContext(ctx, queryGetAll, limit, offset)
+func (pg *Repository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
+) (entity.ProductPage, error) {
+	var (
+		rows      *sql.Rows
+		err       error
+		pageLimit = limit + 1
+	)
+
+	if cursor.Valid {
+		rows, err = pg.db.QueryContext(ctx, queryGetAllAfterCursor, cursor.UUID, pageLimit)
+	} else {
+		rows, err = pg.db.QueryContext(ctx, queryGetAll, pageLimit)
+	}
 	if err != nil {
-		return nil, err
+		return entity.ProductPage{}, err
 	}
 	defer rows.Close()
 
-	var products []entity.Product
+	products := make([]entity.Product, 0, limit+1)
 	for rows.Next() {
 		var p entity.Product
 		var currency string
 		if err := rows.Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency); err != nil {
-			return nil, err
+			return entity.ProductPage{}, err
 		}
 		p.Price.Currency = entity.Currency(currency)
 		products = append(products, p)
 	}
 
 	if err = rows.Err(); err != nil {
-		return nil, err
+		return entity.ProductPage{}, err
 	}
 
-	return products, nil
+	return productPage(products, limit), nil
 }
 
 func (pg *Repository) Update(ctx context.Context, p entity.Product) error {
@@ -184,4 +197,15 @@ func (pg *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 	return nil
+}
+
+func productPage(products []entity.Product, limit int) entity.ProductPage {
+	if len(products) <= limit {
+		return entity.ProductPage{Items: products}
+	}
+
+	return entity.ProductPage{
+		Items:   products[:limit],
+		HasMore: true,
+	}
 }

--- a/internal/repository/postgres_test.go
+++ b/internal/repository/postgres_test.go
@@ -127,20 +127,7 @@ func TestRepository_Save(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name:    "duplicate id",
-			product: entity.Product{ID: uuid.Nil, Name: "Plane", Price: testMoney(10000)},
-			wantErr: true,
-		},
 	}
-
-	seededID := uuid.Must(uuid.NewV7())
-	if _, err := repo.Save(
-		ctx, entity.Product{ID: seededID, Name: "Boat", Price: testMoney(1000)},
-	); err != nil {
-		t.Fatalf("failed to save setup product: %v", err)
-	}
-	tests[3].product.ID = seededID
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -156,6 +143,21 @@ func TestRepository_Save(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("duplicate id", func(t *testing.T) {
+		seededID := uuid.Must(uuid.NewV7())
+		if _, err := repo.Save(
+			ctx, entity.Product{ID: seededID, Name: "Boat", Price: testMoney(1000)},
+		); err != nil {
+			t.Fatalf("failed to save setup product: %v", err)
+		}
+
+		if _, err := repo.Save(
+			ctx, entity.Product{ID: seededID, Name: "Plane", Price: testMoney(10000)},
+		); err == nil {
+			t.Fatal("expected error")
+		}
+	})
 }
 
 func TestRepository_FindByID(t *testing.T) {
@@ -164,7 +166,9 @@ func TestRepository_FindByID(t *testing.T) {
 	ctx := t.Context()
 
 	id := uuid.Must(uuid.NewV7())
-	if _, err := repo.Save(ctx, entity.Product{ID: id, Name: "Car", Price: testMoney(1050)}); err != nil {
+	if _, err := repo.Save(
+		ctx, entity.Product{ID: id, Name: "Car", Price: testMoney(1050)},
+	); err != nil {
 		t.Fatalf("failed to save product: %v", err)
 	}
 
@@ -210,12 +214,15 @@ func TestRepository_FindAll(t *testing.T) {
 	defer cleanup()
 	ctx := t.Context()
 
-	res, err := repo.FindAll(ctx, 50, 0)
+	page, err := repo.FindAll(ctx, uuid.NullUUID{}, 50)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(res) != 0 {
-		t.Errorf("expected 0 products, got %d", len(res))
+	if len(page.Items) != 0 {
+		t.Errorf("expected 0 products, got %d", len(page.Items))
+	}
+	if page.HasMore {
+		t.Error("expected HasMore=false on empty table")
 	}
 
 	p1 := entity.Product{ID: uuid.Must(uuid.NewV7()), Name: "P1", Price: testMoney(100)}
@@ -227,12 +234,53 @@ func TestRepository_FindAll(t *testing.T) {
 		t.Fatalf("failed to save product 2: %v", err)
 	}
 
-	res, err = repo.FindAll(ctx, 50, 0)
+	page, err = repo.FindAll(ctx, uuid.NullUUID{}, 50)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(res) != 2 {
-		t.Errorf("expected 2 products, got %d", len(res))
+	if len(page.Items) != 2 {
+		t.Errorf("expected 2 products, got %d", len(page.Items))
+	}
+	if page.HasMore {
+		t.Error("expected HasMore=false when page is not full")
+	}
+
+	// First keyset page: limit 1 yields p1 and signals more.
+	first, err := repo.FindAll(ctx, uuid.NullUUID{}, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(first.Items) != 1 || first.Items[0].ID != p1.ID {
+		t.Fatalf("expected [p1], got %+v", first.Items)
+	}
+	if !first.HasMore {
+		t.Error("expected HasMore=true on full first page")
+	}
+
+	// Second keyset page: cursor at p1 yields p2 and ends the stream.
+	cursor := uuid.NullUUID{UUID: first.Items[0].ID, Valid: true}
+	second, err := repo.FindAll(ctx, cursor, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(second.Items) != 1 || second.Items[0].ID != p2.ID {
+		t.Fatalf("expected [p2], got %+v", second.Items)
+	}
+	if second.HasMore {
+		t.Error("expected HasMore=false on last page")
+	}
+
+	// Cursor at the last product yields an empty final page.
+	cursor = uuid.NullUUID{UUID: p2.ID, Valid: true}
+	empty, err := repo.FindAll(ctx, cursor, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(empty.Items) != 0 {
+		t.Fatalf("expected empty page, got %+v", empty.Items)
+	}
+	if empty.HasMore {
+		t.Error("expected HasMore=false after last product")
 	}
 }
 
@@ -242,7 +290,9 @@ func TestRepository_Update(t *testing.T) {
 	ctx := t.Context()
 
 	id := uuid.Must(uuid.NewV7())
-	if _, err := repo.Save(ctx, entity.Product{ID: id, Name: "OldName", Price: testMoney(1000)}); err != nil {
+	if _, err := repo.Save(
+		ctx, entity.Product{ID: id, Name: "OldName", Price: testMoney(1000)},
+	); err != nil {
 		t.Fatalf("failed to save product: %v", err)
 	}
 
@@ -303,7 +353,9 @@ func TestRepository_Delete(t *testing.T) {
 	ctx := t.Context()
 
 	id := uuid.Must(uuid.NewV7())
-	if _, err := repo.Save(ctx, entity.Product{ID: id, Name: "ToDelete", Price: testMoney(1000)}); err != nil {
+	if _, err := repo.Save(
+		ctx, entity.Product{ID: id, Name: "ToDelete", Price: testMoney(1000)},
+	); err != nil {
 		t.Fatalf("failed to save product: %v", err)
 	}
 

--- a/internal/repository/queries.go
+++ b/internal/repository/queries.go
@@ -1,9 +1,29 @@
 package repository
 
 const (
-	queryInsert  = "INSERT INTO products (id, name, price_minor, currency) VALUES ($1, $2, $3, $4);"
-	queryGetByID = "SELECT id, name, price_minor, currency FROM products WHERE id = $1;"
-	queryGetAll  = "SELECT id, name, price_minor, currency FROM products ORDER BY id LIMIT $1 OFFSET $2;"
-	queryUpdate  = "UPDATE products SET name = $2, price_minor = $3, currency = $4 WHERE id = $1;"
-	queryDelete  = "DELETE FROM products WHERE id = $1;"
+	queryInsert = `
+		INSERT INTO products (id, name, price_minor, currency)
+		VALUES ($1, $2, $3, $4);`
+	queryGetByID = `
+		SELECT id, name, price_minor, currency
+		FROM products
+		WHERE id = $1;`
+	queryGetAll = `
+		SELECT id, name, price_minor, currency
+		FROM products
+		ORDER BY id
+		LIMIT $1;`
+	queryGetAllAfterCursor = `
+		SELECT id, name, price_minor, currency
+		FROM products
+		WHERE id > $1
+		ORDER BY id
+		LIMIT $2;`
+	queryUpdate = `
+		UPDATE products
+		SET name = $2, price_minor = $3, currency = $4
+		WHERE id = $1;`
+	queryDelete = `
+		DELETE FROM products
+		WHERE id = $1;`
 )

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -17,15 +17,15 @@ type (
 	repository interface {
 		Save(context.Context, entity.Product) (entity.Product, error)
 		FindByID(context.Context, uuid.UUID) (entity.Product, error)
-		FindAll(ctx context.Context, limit, offset int) ([]entity.Product, error)
+		FindAll(context.Context, uuid.NullUUID, int) (entity.ProductPage, error)
 		Update(context.Context, entity.Product) error
 		Delete(context.Context, uuid.UUID) error
 	}
 
 	cacher interface {
-		Set(ctx context.Context, key string, value entity.Product) error
-		Get(ctx context.Context, key string) (entity.Product, error)
-		Invalidate(ctx context.Context, key string) error
+		Set(context.Context, string, entity.Product) error
+		Get(context.Context, string) (entity.Product, error)
+		Invalidate(context.Context, string) error
 	}
 
 	Service struct {
@@ -99,8 +99,9 @@ func (s *Service) loadProduct(ctx context.Context, id uuid.UUID) (entity.Product
 	return p, nil
 }
 
-func (s *Service) FindAll(ctx context.Context, limit, offset int) ([]entity.Product, error) {
-	return s.repo.FindAll(ctx, limit, offset)
+func (s *Service) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
+) (entity.ProductPage, error) {
+	return s.repo.FindAll(ctx, cursor, limit)
 }
 
 func (s *Service) Update(ctx context.Context, p entity.Product) error {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -37,11 +37,11 @@ func testMoney(amount int64) entity.Money {
 }
 
 type MockRepository struct {
-	SaveFn     func(ctx context.Context, p entity.Product) (entity.Product, error)
-	FindByIDFn func(ctx context.Context, id uuid.UUID) (entity.Product, error)
-	FindAllFn  func(ctx context.Context, limit, offset int) ([]entity.Product, error)
-	UpdateFn   func(ctx context.Context, p entity.Product) error
-	DeleteFn   func(ctx context.Context, id uuid.UUID) error
+	SaveFn     func(context.Context, entity.Product) (entity.Product, error)
+	FindByIDFn func(context.Context, uuid.UUID) (entity.Product, error)
+	FindAllFn  func(context.Context, uuid.NullUUID, int) (entity.ProductPage, error)
+	UpdateFn   func(context.Context, entity.Product) error
+	DeleteFn   func(context.Context, uuid.UUID) error
 }
 
 func (m *MockRepository) Save(ctx context.Context, p entity.Product) (entity.Product, error) {
@@ -52,8 +52,9 @@ func (m *MockRepository) FindByID(ctx context.Context, id uuid.UUID) (entity.Pro
 	return m.FindByIDFn(ctx, id)
 }
 
-func (m *MockRepository) FindAll(ctx context.Context, limit, offset int) ([]entity.Product, error) {
-	return m.FindAllFn(ctx, limit, offset)
+func (m *MockRepository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
+) (entity.ProductPage, error) {
+	return m.FindAllFn(ctx, cursor, limit)
 }
 
 func (m *MockRepository) Update(ctx context.Context, p entity.Product) error {
@@ -220,8 +221,10 @@ func TestService_FindAll(t *testing.T) {
 		{
 			name: "success",
 			mockSetup: func(m *MockRepository) {
-				m.FindAllFn = func(_ context.Context, _, _ int) ([]entity.Product, error) {
-					return []entity.Product{{Name: "P1", Price: testMoney(100)}, {Name: "P2", Price: testMoney(200)}}, nil
+				m.FindAllFn = func(_ context.Context, _ uuid.NullUUID, _ int) (entity.ProductPage, error) {
+					return entity.ProductPage{Items: []entity.Product{
+						{Name: "P1", Price: testMoney(100)}, {Name: "P2", Price: testMoney(200)},
+					}}, nil
 				}
 			},
 			wantLen: 2,
@@ -235,7 +238,7 @@ func TestService_FindAll(t *testing.T) {
 			tt.mockSetup(mockRepo)
 			srv := newTestService(mockRepo)
 
-			res, err := srv.FindAll(ctx, 50, 0)
+			page, err := srv.FindAll(ctx, uuid.NullUUID{}, 50)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")
@@ -245,8 +248,8 @@ func TestService_FindAll(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if len(res) != tt.wantLen {
-				t.Errorf("got length %d, want %d", len(res), tt.wantLen)
+			if len(page.Items) != tt.wantLen {
+				t.Errorf("got length %d, want %d", len(page.Items), tt.wantLen)
 			}
 		})
 	}


### PR DESCRIPTION
Replace LIMIT/OFFSET with cursor-based keyset pagination over the UUID v7 primary key 

- opaque cursor passed as ?cursor=<uuid>; empty = first page
- response envelope {items, nextCursor}; missing nextCursor = last page
- fetch limit+1 to detect the next page without a COUNT
- entity.ProductPage{Items, HasMore} as the result type across layers
- drop offset entirely