### PR TITLE
refactor: migrate repository to pgxpool

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -17,8 +16,7 @@ import (
 	"github.com/alkmc/storefront/internal/migrate"
 	"github.com/alkmc/storefront/internal/repository"
 	"github.com/alkmc/storefront/internal/service"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/rueidis"
 	"golang.org/x/sync/errgroup"
 )
@@ -47,13 +45,13 @@ func run(logger *slog.Logger, cfg config.Config) error {
 		return err
 	}
 
-	db, err := openPostgres(ctx, cfg.Postgres)
+	pool, err := openPostgres(ctx, cfg.Postgres)
 	if err != nil {
 		return err
 	}
 	logger.Info("successfully connected to db")
 	defer func() {
-		_ = db.Close()
+		pool.Close()
 		logger.Info("connection to db closed")
 	}()
 
@@ -67,7 +65,7 @@ func run(logger *slog.Logger, cfg config.Config) error {
 		logger.Info("connection to redis closed")
 	}()
 
-	repo := repository.New(db)
+	repo := repository.New(pool)
 	rCache := cache.New(client, cfg.Redis.TTL)
 	srv := service.NewService(logger, repo, rCache, cfg.Service.LoadTimeout)
 
@@ -133,22 +131,25 @@ func run(logger *slog.Logger, cfg config.Config) error {
 	return nil
 }
 
-// openPostgres opens a database/sql pool over pgx and verifies it with a ping.
-func openPostgres(ctx context.Context, cfg config.Postgres) (*sql.DB, error) {
-	pgCfg, err := pgx.ParseConfig(cfg.DSN())
+// openPostgres opens a pgx connection pool and verifies it with a ping.
+func openPostgres(ctx context.Context, cfg config.Postgres) (*pgxpool.Pool, error) {
+	poolCfg, err := pgxpool.ParseConfig(cfg.DSN())
 	if err != nil {
 		return nil, fmt.Errorf("parse pg config: %w", err)
 	}
-	db := stdlib.OpenDB(*pgCfg)
-	db.SetMaxOpenConns(cfg.MaxOpenConns)
-	db.SetMaxIdleConns(cfg.MaxIdleConns)
-	db.SetConnMaxLifetime(cfg.ConnMaxLifetime)
+	poolCfg.MaxConns = cfg.MaxOpenConns
+	poolCfg.MinConns = cfg.MaxIdleConns
+	poolCfg.MaxConnLifetime = cfg.ConnMaxLifetime
 
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return nil, fmt.Errorf("create pg pool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
 		return nil, fmt.Errorf("ping pg database: %w", err)
 	}
-	return db, nil
+	return pool, nil
 }
 
 // openRedis creates a rueidis client and verifies it with a ping.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,8 +46,8 @@ type (
 		Password        Secret        `env:"PG_PASSWORD,required,unset"`
 		Database        string        `env:"PG_DB,required"`
 		SSLMode         string        `env:"PG_SSLMODE" envDefault:"disable"`
-		MaxOpenConns    int           `env:"PG_MAX_OPEN_CONNS" envDefault:"25"`
-		MaxIdleConns    int           `env:"PG_MAX_IDLE_CONNS" envDefault:"5"`
+		MaxOpenConns    int32         `env:"PG_MAX_OPEN_CONNS" envDefault:"25"`
+		MaxIdleConns    int32         `env:"PG_MAX_IDLE_CONNS" envDefault:"5"`
 		ConnMaxLifetime time.Duration `env:"PG_CONN_MAX_LIFETIME" envDefault:"30m"`
 	}
 	Redis struct {

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -2,28 +2,29 @@ package repository
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 
 	"github.com/alkmc/storefront/internal/entity"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type Repository struct {
-	db *sql.DB
+	pool *pgxpool.Pool
 }
 
-// New wraps an open database handle in a repository.
-func New(db *sql.DB) *Repository {
-	return new(Repository{db: db})
+// New wraps an open connection pool in a repository.
+func New(pool *pgxpool.Pool) *Repository {
+	return new(Repository{pool: pool})
 }
 
 func (pg *Repository) Ping(ctx context.Context) error {
-	return pg.db.PingContext(ctx)
+	return pg.pool.Ping(ctx)
 }
 
 func (pg *Repository) Save(ctx context.Context, p entity.Product) (entity.Product, error) {
-	if _, err := pg.db.ExecContext(
+	if _, err := pg.pool.Exec(
 		ctx, queryInsert, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency),
 	); err != nil {
 		return entity.Product{}, err
@@ -32,12 +33,12 @@ func (pg *Repository) Save(ctx context.Context, p entity.Product) (entity.Produc
 }
 
 func (pg *Repository) FindByID(ctx context.Context, id uuid.UUID) (entity.Product, error) {
-	row := pg.db.QueryRowContext(ctx, queryGetByID, id)
+	row := pg.pool.QueryRow(ctx, queryGetByID, id)
 
 	var p entity.Product
 	var currency string
 	if err := row.Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return entity.Product{}, entity.ErrNotFound
 		}
 		return entity.Product{}, err
@@ -49,15 +50,15 @@ func (pg *Repository) FindByID(ctx context.Context, id uuid.UUID) (entity.Produc
 func (pg *Repository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
 ) (entity.ProductPage, error) {
 	var (
-		rows      *sql.Rows
+		rows      pgx.Rows
 		err       error
 		pageLimit = limit + 1
 	)
 
 	if cursor.Valid {
-		rows, err = pg.db.QueryContext(ctx, queryGetAllAfterCursor, cursor.UUID, pageLimit)
+		rows, err = pg.pool.Query(ctx, queryGetAllAfterCursor, cursor.UUID, pageLimit)
 	} else {
-		rows, err = pg.db.QueryContext(ctx, queryGetAll, pageLimit)
+		rows, err = pg.pool.Query(ctx, queryGetAll, pageLimit)
 	}
 	if err != nil {
 		return entity.ProductPage{}, err
@@ -83,30 +84,22 @@ func (pg *Repository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit i
 }
 
 func (pg *Repository) Update(ctx context.Context, p entity.Product) error {
-	res, err := pg.db.ExecContext(ctx, queryUpdate, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency))
+	res, err := pg.pool.Exec(ctx, queryUpdate, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency))
 	if err != nil {
 		return err
 	}
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
+	if res.RowsAffected() == 0 {
 		return entity.ErrNotFound
 	}
 	return nil
 }
 
 func (pg *Repository) Delete(ctx context.Context, id uuid.UUID) error {
-	res, err := pg.db.ExecContext(ctx, queryDelete, id)
+	res, err := pg.pool.Exec(ctx, queryDelete, id)
 	if err != nil {
 		return err
 	}
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
+	if res.RowsAffected() == 0 {
 		return entity.ErrNotFound
 	}
 	return nil

--- a/internal/repository/postgres_test.go
+++ b/internal/repository/postgres_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alkmc/storefront/internal/migrate"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -62,7 +63,9 @@ func setupTestContainerDB(t *testing.T) (*Repository, func()) {
 		SSLMode:  "disable",
 	}
 
-	pgxCfg, err := pgx.ParseConfig(pgConfig.DSN())
+	dsn := pgConfig.DSN()
+
+	pgxCfg, err := pgx.ParseConfig(dsn)
 	if err != nil {
 		t.Fatalf("failed to parse pg config: %v", err)
 	}
@@ -74,15 +77,18 @@ func setupTestContainerDB(t *testing.T) (*Repository, func()) {
 		t.Fatalf("failed to close migration db: %v", err)
 	}
 
-	db := stdlib.OpenDB(*pgxCfg)
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("failed to create pg pool: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
 		t.Fatalf("failed to ping db: %v", err)
 	}
-	repo := New(db)
+	repo := New(pool)
 
 	cleanup := func() {
-		_ = db.Close()
+		pool.Close()
 		if err := pgContainer.Terminate(context.Background()); err != nil {
 			t.Fatalf("failed to terminate pg container: %v", err)
 		}


### PR DESCRIPTION
Migrate the repository from database/sql to pgxpool.Pool:
- database/sql can't reach the pgx-native features the upcoming work needs
- enables pgx.CopyFrom for the planned bulk-import endpoint
- Enables LISTEN/NOTIFY on a dedicated connection for the outbox dispatcher
- Pool opened in main and injected into repository.New