### PR TITLE
feat: map database outages to 503

### DIFF
--- a/internal/entity/product.go
+++ b/internal/entity/product.go
@@ -6,8 +6,12 @@ import (
 	"github.com/google/uuid"
 )
 
-// ErrNotFound signals a missing aggregate at the domain boundary.
-var ErrNotFound = errors.New("entity: not found")
+var (
+	// ErrNotFound signals a missing aggregate at the domain boundary.
+	ErrNotFound = errors.New("entity: not found")
+	// ErrUnavailable signals that a backing dependency is temporarily unavailable.
+	ErrUnavailable = errors.New("entity: dependency unavailable")
+)
 
 type (
 	// Product represents a purchasable item in the system

--- a/internal/httpapi/codec.go
+++ b/internal/httpapi/codec.go
@@ -18,6 +18,7 @@ const (
 	msgMalformedJSON = "request body contains malformed JSON"
 	msgInvalidBody   = "invalid request body"
 	msgInternalError = "internal server error"
+	msgUnavailable   = "service temporarily unavailable"
 )
 
 type messageResponse struct {

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -66,8 +66,8 @@ func (h *Handler) GetByID(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusNotFound, "product not found")
 			return
 		}
-		h.internalError(
-			w, "failed to find product by id",
+		h.respondServerError(
+			w, err, "failed to find product by id",
 			slog.Any("error", err), slog.String("id", id.String()),
 		)
 		return
@@ -93,7 +93,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 
 	page, err := h.processor.FindAll(ctx, cursor, limit)
 	if err != nil {
-		h.internalError(w, "failed to find all products", slog.Any("error", err))
+		h.respondServerError(w, err, "failed to find all products", slog.Any("error", err))
 		return
 	}
 	respond(w, http.StatusOK, toProductsPage(page))
@@ -123,7 +123,7 @@ func (h *Handler) Add(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.processor.Create(ctx, p)
 	if err != nil {
-		h.internalError(w, "failed to create product", slog.Any("error", err))
+		h.respondServerError(w, err, "failed to create product", slog.Any("error", err))
 		return
 	}
 	respond(w, http.StatusCreated, toProductResponse(result))
@@ -144,8 +144,8 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusNotFound, "unable to delete product, which does not exist")
 			return
 		}
-		h.internalError(
-			w, "failed to delete product",
+		h.respondServerError(
+			w, err, "failed to delete product",
 			slog.Any("error", err), slog.String("id", id.String()),
 		)
 		return
@@ -186,11 +186,23 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusNotFound, "unable to update product, which does not exist")
 			return
 		}
-		h.internalError(w, "failed to update product",
-			slog.Any("error", err), slog.String("id", id.String()))
+		h.respondServerError(
+			w, err, "failed to update product",
+			slog.Any("error", err), slog.String("id", id.String()),
+		)
 		return
 	}
 	respond(w, http.StatusOK, toProductResponse(p))
+}
+
+// respondServerError maps infrastructure failures to 503 or 500 and logs them.
+func (h *Handler) respondServerError(w http.ResponseWriter, err error, logMsg string, attrs ...any) {
+	if errors.Is(err, entity.ErrUnavailable) {
+		h.logger.Warn(logMsg, attrs...)
+		respondError(w, http.StatusServiceUnavailable, msgUnavailable)
+		return
+	}
+	h.internalError(w, logMsg, attrs...)
 }
 
 // internalError logs the failure with attrs and replies with a generic 500.

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -384,6 +385,25 @@ func TestAddProduct(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestServiceUnavailable(t *testing.T) {
+	mux, proc := setupTest(t, testHTTPConfig)
+	proc.findByID = func(_ context.Context, _ uuid.UUID) (entity.Product, error) {
+		return entity.Product{}, fmt.Errorf("query failed: %w", entity.ErrUnavailable)
+	}
+
+	id := uuid.Must(uuid.NewV7()).String()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/product/"+id, nil)
+	resp := httptest.NewRecorder()
+	mux.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Errorf("got status %d, want %d", resp.Code, http.StatusServiceUnavailable)
+	}
+	if e := decodeJSON[messageResponse](t, resp.Body); e.Message != msgUnavailable {
+		t.Errorf("got msg %q, want %q", e.Message, msgUnavailable)
 	}
 }
 

--- a/internal/repository/maperr_test.go
+++ b/internal/repository/maperr_test.go
@@ -1,0 +1,78 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/alkmc/storefront/internal/entity"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestMapDBError(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		wantUnavailable bool
+	}{
+		{
+			name:            "nil",
+			err:             nil,
+			wantUnavailable: false,
+		},
+		{
+			name:            "context canceled",
+			err:             context.Canceled,
+			wantUnavailable: false,
+		},
+		{
+			name:            "context deadline",
+			err:             context.DeadlineExceeded,
+			wantUnavailable: false,
+		},
+		{
+			name:            "pg connection failure",
+			err:             &pgconn.PgError{Code: "08006"},
+			wantUnavailable: true,
+		},
+		{
+			name:            "pg insufficient resources",
+			err:             &pgconn.PgError{Code: "53300"},
+			wantUnavailable: true,
+		},
+		{
+			name:            "pg admin shutdown",
+			err:             &pgconn.PgError{Code: "57P01"},
+			wantUnavailable: true,
+		},
+		{
+			name:            "pg unique violation",
+			err:             &pgconn.PgError{Code: "23505"},
+			wantUnavailable: false,
+		},
+		{
+			name:            "net error",
+			err:             &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			wantUnavailable: true,
+		},
+		{
+			name:            "plain error",
+			err:             errors.New("boom"),
+			wantUnavailable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapDBError(tt.err)
+			gotUnavail := errors.Is(got, entity.ErrUnavailable)
+			if gotUnavail != tt.wantUnavailable {
+				t.Fatalf("mapDBError(%v): got unavailable=%v, want %v", tt.err, gotUnavail, tt.wantUnavailable)
+			}
+			if tt.err != nil && !errors.Is(got, tt.err) {
+				t.Errorf("original error not preserved in chain: %v", got)
+			}
+		})
+	}
+}

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -3,11 +3,25 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 
 	"github.com/alkmc/storefront/internal/entity"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	// A SQLSTATE code is 5 characters; its first 2 identify the error class.
+	sqlStateLen      = 5
+	sqlStateClassLen = 2
+	// SQLSTATE classes that signal the database is temporarily unavailable.
+	classConnectionException   = "08"
+	classInsufficientResources = "53"
+	classOperatorIntervention  = "57"
+	classSystemError           = "58"
 )
 
 type Repository struct {
@@ -27,7 +41,7 @@ func (pg *Repository) Save(ctx context.Context, p entity.Product) (entity.Produc
 	if _, err := pg.pool.Exec(
 		ctx, queryInsert, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency),
 	); err != nil {
-		return entity.Product{}, err
+		return entity.Product{}, mapDBError(err)
 	}
 	return p, nil
 }
@@ -41,7 +55,7 @@ func (pg *Repository) FindByID(ctx context.Context, id uuid.UUID) (entity.Produc
 		if errors.Is(err, pgx.ErrNoRows) {
 			return entity.Product{}, entity.ErrNotFound
 		}
-		return entity.Product{}, err
+		return entity.Product{}, mapDBError(err)
 	}
 	p.Price.Currency = entity.Currency(currency)
 	return p, nil
@@ -61,7 +75,7 @@ func (pg *Repository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit i
 		rows, err = pg.pool.Query(ctx, queryGetAll, pageLimit)
 	}
 	if err != nil {
-		return entity.ProductPage{}, err
+		return entity.ProductPage{}, mapDBError(err)
 	}
 	defer rows.Close()
 
@@ -70,14 +84,14 @@ func (pg *Repository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit i
 		var p entity.Product
 		var currency string
 		if err := rows.Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency); err != nil {
-			return entity.ProductPage{}, err
+			return entity.ProductPage{}, mapDBError(err)
 		}
 		p.Price.Currency = entity.Currency(currency)
 		products = append(products, p)
 	}
 
 	if err = rows.Err(); err != nil {
-		return entity.ProductPage{}, err
+		return entity.ProductPage{}, mapDBError(err)
 	}
 
 	return productPage(products, limit), nil
@@ -86,7 +100,7 @@ func (pg *Repository) FindAll(ctx context.Context, cursor uuid.NullUUID, limit i
 func (pg *Repository) Update(ctx context.Context, p entity.Product) error {
 	res, err := pg.pool.Exec(ctx, queryUpdate, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency))
 	if err != nil {
-		return err
+		return mapDBError(err)
 	}
 	if res.RowsAffected() == 0 {
 		return entity.ErrNotFound
@@ -97,12 +111,34 @@ func (pg *Repository) Update(ctx context.Context, p entity.Product) error {
 func (pg *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 	res, err := pg.pool.Exec(ctx, queryDelete, id)
 	if err != nil {
-		return err
+		return mapDBError(err)
 	}
 	if res.RowsAffected() == 0 {
 		return entity.ErrNotFound
 	}
 	return nil
+}
+
+// mapDBError tags connection-class failures as entity.ErrUnavailable.
+func mapDBError(err error) error {
+	if err == nil ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+		if code := pgErr.Code; len(code) == sqlStateLen {
+			switch code[:sqlStateClassLen] {
+			case classConnectionException, classInsufficientResources,
+				classOperatorIntervention, classSystemError:
+				return fmt.Errorf("%w: %w", entity.ErrUnavailable, err)
+			}
+		}
+		return err
+	}
+	if _, ok := errors.AsType[net.Error](err); ok {
+		return fmt.Errorf("%w: %w", entity.ErrUnavailable, err)
+	}
+	return err
 }
 
 func productPage(products []entity.Product, limit int) entity.ProductPage {


### PR DESCRIPTION
- DB down previously returned a generic 500, so clients could not tell a retryable outage from a real bug
- Add entity.ErrUnavailable and repository mapDBError, which tags connection class failures 
(SQLSTATE classes 08/53/57/58, net.Error) and wraps them on every query path.
- Handler respondServerError maps ErrUnavailable to 503, ErrNotFound to 404, everything else to 500.
- Ping stays unwrapped because the readiness probe already treats any ping error as 503.
- Tests cover mapDBError as a unit table and the 503 handler path.