### PR TITLE
refactor: move keyset pagination helpers to domain

### DIFF
--- a/internal/domain/pagination.go
+++ b/internal/domain/pagination.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// DefaultPageSize is used when a client omits or under-specifies a page limit.
+	DefaultPageSize = 50
+	// MaxPageSize caps a client-requested page size.
+	MaxPageSize = 200
+)
+
+// ClampPageSize bounds n into (0, MaxPageSize], defaulting non-positive values.
+func ClampPageSize(n int) int {
+	if n <= 0 {
+		return DefaultPageSize
+	}
+	return min(n, MaxPageSize)
+}
+
+// ParseCursor turns an optional id string into a keyset cursor.
+func ParseCursor(raw string) (uuid.NullUUID, error) {
+	if raw == "" {
+		return uuid.NullUUID{}, nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.NullUUID{}, fmt.Errorf("invalid cursor: %q", raw)
+	}
+	return uuid.NullUUID{UUID: id, Valid: true}, nil
+}
+
+// NextCursor returns the id to resume after, or "" when this is the last page.
+func (p ProductPage) NextCursor() string {
+	if !p.HasMore || len(p.Items) == 0 {
+		return ""
+	}
+	return p.Items[len(p.Items)-1].ID.String()
+}

--- a/internal/domain/pagination.go
+++ b/internal/domain/pagination.go
@@ -13,8 +13,8 @@ const (
 	MaxPageSize = 200
 )
 
-// ClampPageSize bounds n into (0, MaxPageSize], defaulting non-positive values.
-func ClampPageSize(n int) int {
+// NormalizePageSize bounds n into (0, MaxPageSize], defaulting non-positive values.
+func NormalizePageSize(n int) int {
 	if n <= 0 {
 		return DefaultPageSize
 	}

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -97,10 +97,6 @@ func setupTestContainerDB(t *testing.T) (*Postgres, func()) {
 	return repo, cleanup
 }
 
-func testMoney(amount int64) domain.Money {
-	return domain.Money{MinorAmount: amount, Currency: domain.CurrencyPLN}
-}
-
 func TestPostgres_Save(t *testing.T) {
 	repo, cleanup := setupTestContainerDB(t)
 	defer cleanup()
@@ -397,4 +393,8 @@ func TestPostgres_Delete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testMoney(amount int64) domain.Money {
+	return domain.Money{MinorAmount: amount, Currency: domain.CurrencyPLN}
 }

--- a/internal/transport/grpc/dto.go
+++ b/internal/transport/grpc/dto.go
@@ -1,16 +1,8 @@
 package grpc
 
 import (
-	"fmt"
-
 	catalogv1 "github.com/alkmc/storefront/api/gen/catalog/v1"
 	"github.com/alkmc/storefront/internal/domain"
-	"github.com/google/uuid"
-)
-
-const (
-	defaultLimit = 50
-	maxLimit     = 200
 )
 
 func toProto(p domain.Product) *catalogv1.Product {
@@ -37,32 +29,4 @@ func toDomainMoney(m *catalogv1.Money) domain.Money {
 		MinorAmount: m.GetMinorAmount(),
 		Currency:    domain.Currency(m.GetCurrency()),
 	}
-}
-
-// normalizeLimit clamps a requested page size into (0, maxLimit].
-func normalizeLimit(n int) int {
-	if n <= 0 {
-		return defaultLimit
-	}
-	return min(n, maxLimit)
-}
-
-// parseCursor turns an optional id string into a keyset cursor.
-func parseCursor(raw string) (uuid.NullUUID, error) {
-	if raw == "" {
-		return uuid.NullUUID{}, nil
-	}
-	id, err := uuid.Parse(raw)
-	if err != nil {
-		return uuid.NullUUID{}, fmt.Errorf("invalid cursor: %q", raw)
-	}
-	return uuid.NullUUID{UUID: id, Valid: true}, nil
-}
-
-// nextCursor returns the id to resume after, or "" when the page is last.
-func nextCursor(page domain.ProductPage) string {
-	if !page.HasMore || len(page.Items) == 0 {
-		return ""
-	}
-	return page.Items[len(page.Items)-1].ID.String()
 }

--- a/internal/transport/grpc/handler.go
+++ b/internal/transport/grpc/handler.go
@@ -65,17 +65,17 @@ func (h *Handler) GetProduct(
 func (h *Handler) ListProducts(
 	ctx context.Context, req *catalogv1.ListProductsRequest,
 ) (*catalogv1.ListProductsResponse, error) {
-	cursor, err := parseCursor(req.GetCursor())
+	cursor, err := domain.ParseCursor(req.GetCursor())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	page, err := h.processor.FindAll(ctx, cursor, normalizeLimit(int(req.GetLimit())))
+	page, err := h.processor.FindAll(ctx, cursor, domain.ClampPageSize(int(req.GetLimit())))
 	if err != nil {
 		return nil, h.toStatus(err, "list products")
 	}
 	return catalogv1.ListProductsResponse_builder{
 		Products:   toProtos(page.Items),
-		NextCursor: nextCursor(page),
+		NextCursor: page.NextCursor(),
 	}.Build(), nil
 }
 

--- a/internal/transport/grpc/handler.go
+++ b/internal/transport/grpc/handler.go
@@ -69,7 +69,7 @@ func (h *Handler) ListProducts(
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	page, err := h.processor.FindAll(ctx, cursor, domain.ClampPageSize(int(req.GetLimit())))
+	page, err := h.processor.FindAll(ctx, cursor, domain.NormalizePageSize(int(req.GetLimit())))
 	if err != nil {
 		return nil, h.toStatus(err, "list products")
 	}

--- a/internal/transport/http/dto.go
+++ b/internal/transport/http/dto.go
@@ -36,15 +36,8 @@ func toProductsResponse(ps []domain.Product) []productResponse {
 func toProductsPage(page domain.ProductPage) productsPage {
 	return productsPage{
 		Items:      toProductsResponse(page.Items),
-		NextCursor: nextCursor(page),
+		NextCursor: page.NextCursor(),
 	}
-}
-
-func nextCursor(page domain.ProductPage) string {
-	if !page.HasMore || len(page.Items) == 0 {
-		return ""
-	}
-	return page.Items[len(page.Items)-1].ID.String()
 }
 
 func toMoney(in moneyInput) domain.Money {

--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -214,5 +214,5 @@ func parseLimit(raw string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid limit: %q", raw)
 	}
-	return domain.ClampPageSize(n), nil
+	return domain.NormalizePageSize(n), nil
 }

--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -13,11 +13,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const (
-	defaultLimit = 50
-	maxLimit     = 200
-)
-
 type (
 	processor interface {
 		Create(context.Context, domain.Product) (domain.Product, error)
@@ -82,7 +77,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	cursor, err := parseCursor(q.Get("cursor"))
+	cursor, err := domain.ParseCursor(q.Get("cursor"))
 	if err != nil {
 		respondError(w, http.StatusBadRequest, err.Error())
 		return
@@ -213,25 +208,11 @@ func (h *Handler) internalError(w http.ResponseWriter, msg string, attrs ...any)
 
 func parseLimit(raw string) (int, error) {
 	if raw == "" {
-		return defaultLimit, nil
+		return domain.DefaultPageSize, nil
 	}
 	n, err := strconv.Atoi(raw)
 	if err != nil {
 		return 0, fmt.Errorf("invalid limit: %q", raw)
 	}
-	if n <= 0 {
-		return defaultLimit, nil
-	}
-	return min(n, maxLimit), nil
-}
-
-func parseCursor(raw string) (uuid.NullUUID, error) {
-	if raw == "" {
-		return uuid.NullUUID{}, nil
-	}
-	id, err := uuid.Parse(raw)
-	if err != nil {
-		return uuid.NullUUID{}, fmt.Errorf("invalid cursor: %q", raw)
-	}
-	return uuid.NullUUID{UUID: id, Valid: true}, nil
+	return domain.ClampPageSize(n), nil
 }


### PR DESCRIPTION
- add domain ParseCursor, ClampPageSize and ProductPage.NextCursor with page size bounds
- drop duplicated cursor and next cursor helpers from the http and grpc transports
- domain.ClampPageSize-> domain.NormalizePageSize