### PR TITLE
feat: implement product stock, optimistic versioning, and purchase API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ All available variables with their defaults are documented in `.env.example`.
 ## API
 
 ```bash
-# create a product
+# create a product (stock is optional, defaults to 0)
 curl -s -X POST http://localhost:7000/v1/product \
   -H 'Content-Type: application/json' \
-  -d '{"name":"widget","price":{"minorAmount":999,"currency":"PLN"}}'
+  -d '{"name":"widget","stock":10,"price":{"minorAmount":999,"currency":"PLN"}}'
 
 # get a product by id
 curl -s http://localhost:7000/v1/product/{id}
@@ -50,9 +50,17 @@ curl -s http://localhost:7000/v1/product/{id}
 curl -s 'http://localhost:7000/v1/product?limit=10'
 # next page: pass the nextCursor from the previous response
 curl -s 'http://localhost:7000/v1/product?limit=10&cursor={nextCursor}'
+
+# purchase units, decrementing stock atomically
+curl -s -X POST http://localhost:7000/v1/product/{id}/purchase \
+  -H 'Content-Type: application/json' \
+  -d '{"quantity":2}'
 ```
 
 The list endpoint returns `{"items":[...],"nextCursor":"<id>"}`; a missing `nextCursor` means the last page.
+
+Stock is set at creation and changed only through purchase; `PUT` does not accept a `stock` field.
+Purchase returns `{"productId":"<id>","quantity":2,"remainingStock":8}`; `409` signals insufficient stock.
 
 See `api.rest` for the full set of example requests.
 
@@ -67,8 +75,8 @@ with a registered gRPC health service. The contract lives in
 ```bash
 PROTO="-import-path api/proto -proto catalog/v1/product.proto"
 
-# create a product
-grpcurl -plaintext $PROTO -d '{"name":"widget","price":{"minorAmount":999,"currency":"PLN"}}' \
+# create a product (stock is optional, defaults to 0)
+grpcurl -plaintext $PROTO -d '{"name":"widget","stock":10,"price":{"minorAmount":999,"currency":"PLN"}}' \
   localhost:9090 catalog.v1.ProductService/CreateProduct
 
 # get a product by id
@@ -78,6 +86,10 @@ grpcurl -plaintext $PROTO -d '{"id":"<id>"}' \
 # list products (keyset pagination)
 grpcurl -plaintext $PROTO -d '{"limit":10}' \
   localhost:9090 catalog.v1.ProductService/ListProducts
+
+# purchase units (FAILED_PRECONDITION on insufficient stock)
+grpcurl -plaintext $PROTO -d '{"id":"<id>","quantity":2}' \
+  localhost:9090 catalog.v1.ProductService/PurchaseProduct
 ```
 
 ## Architecture

--- a/api.rest
+++ b/api.rest
@@ -6,13 +6,14 @@
 @apiBase = {{baseUrl}}/v1
 @json = application/json
 
-### CREATE PRODUCT 
+### CREATE PRODUCT
 # @name newproduct
 POST {{apiBase}}/product
 Content-Type: {{json}}
 
 {
     "name": "product",
+    "stock": 10,
     "price": {
         "minorAmount": 9,
         "currency": "PLN"
@@ -41,6 +42,14 @@ Content-Type: {{json}}
         "minorAmount": 2006,
         "currency": "PLN"
     }
+}
+
+### PURCHASE PRODUCT
+POST {{apiBase}}/product/{{prodID}}/purchase
+Content-Type: {{json}}
+
+{
+    "quantity": 2
 }
 
 ### DELETE PRODUCT

--- a/api/gen/catalog/v1/product.pb.go
+++ b/api/gen/catalog/v1/product.pb.go
@@ -98,6 +98,7 @@ type Product struct {
 	xxx_hidden_Id    string                 `protobuf:"bytes,1,opt,name=id"`
 	xxx_hidden_Name  string                 `protobuf:"bytes,2,opt,name=name"`
 	xxx_hidden_Price *Money                 `protobuf:"bytes,3,opt,name=price"`
+	xxx_hidden_Stock int64                  `protobuf:"varint,4,opt,name=stock"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -148,6 +149,13 @@ func (x *Product) GetPrice() *Money {
 	return nil
 }
 
+func (x *Product) GetStock() int64 {
+	if x != nil {
+		return x.xxx_hidden_Stock
+	}
+	return 0
+}
+
 func (x *Product) SetId(v string) {
 	x.xxx_hidden_Id = v
 }
@@ -158,6 +166,10 @@ func (x *Product) SetName(v string) {
 
 func (x *Product) SetPrice(v *Money) {
 	x.xxx_hidden_Price = v
+}
+
+func (x *Product) SetStock(v int64) {
+	x.xxx_hidden_Stock = v
 }
 
 func (x *Product) HasPrice() bool {
@@ -177,6 +189,7 @@ type Product_builder struct {
 	Id    string
 	Name  string
 	Price *Money
+	Stock int64
 }
 
 func (b0 Product_builder) Build() *Product {
@@ -186,6 +199,7 @@ func (b0 Product_builder) Build() *Product {
 	x.xxx_hidden_Id = b.Id
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_Price = b.Price
+	x.xxx_hidden_Stock = b.Stock
 	return m0
 }
 
@@ -193,6 +207,7 @@ type CreateProductRequest struct {
 	state            protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name"`
 	xxx_hidden_Price *Money                 `protobuf:"bytes,2,opt,name=price"`
+	xxx_hidden_Stock int64                  `protobuf:"varint,3,opt,name=stock"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -236,12 +251,23 @@ func (x *CreateProductRequest) GetPrice() *Money {
 	return nil
 }
 
+func (x *CreateProductRequest) GetStock() int64 {
+	if x != nil {
+		return x.xxx_hidden_Stock
+	}
+	return 0
+}
+
 func (x *CreateProductRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
 
 func (x *CreateProductRequest) SetPrice(v *Money) {
 	x.xxx_hidden_Price = v
+}
+
+func (x *CreateProductRequest) SetStock(v int64) {
+	x.xxx_hidden_Stock = v
 }
 
 func (x *CreateProductRequest) HasPrice() bool {
@@ -260,6 +286,7 @@ type CreateProductRequest_builder struct {
 
 	Name  string
 	Price *Money
+	Stock int64
 }
 
 func (b0 CreateProductRequest_builder) Build() *CreateProductRequest {
@@ -268,6 +295,7 @@ func (b0 CreateProductRequest_builder) Build() *CreateProductRequest {
 	_, _ = b, x
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_Price = b.Price
+	x.xxx_hidden_Stock = b.Stock
 	return m0
 }
 
@@ -872,6 +900,162 @@ func (b0 DeleteProductResponse_builder) Build() *DeleteProductResponse {
 	return m0
 }
 
+type PurchaseProductRequest struct {
+	state               protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Id       string                 `protobuf:"bytes,1,opt,name=id"`
+	xxx_hidden_Quantity int64                  `protobuf:"varint,2,opt,name=quantity"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *PurchaseProductRequest) Reset() {
+	*x = PurchaseProductRequest{}
+	mi := &file_catalog_v1_product_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PurchaseProductRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PurchaseProductRequest) ProtoMessage() {}
+
+func (x *PurchaseProductRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_catalog_v1_product_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PurchaseProductRequest) GetId() string {
+	if x != nil {
+		return x.xxx_hidden_Id
+	}
+	return ""
+}
+
+func (x *PurchaseProductRequest) GetQuantity() int64 {
+	if x != nil {
+		return x.xxx_hidden_Quantity
+	}
+	return 0
+}
+
+func (x *PurchaseProductRequest) SetId(v string) {
+	x.xxx_hidden_Id = v
+}
+
+func (x *PurchaseProductRequest) SetQuantity(v int64) {
+	x.xxx_hidden_Quantity = v
+}
+
+type PurchaseProductRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Id       string
+	Quantity int64
+}
+
+func (b0 PurchaseProductRequest_builder) Build() *PurchaseProductRequest {
+	m0 := &PurchaseProductRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Id = b.Id
+	x.xxx_hidden_Quantity = b.Quantity
+	return m0
+}
+
+type PurchaseProductResponse struct {
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ProductId      string                 `protobuf:"bytes,1,opt,name=product_id,json=productId"`
+	xxx_hidden_Quantity       int64                  `protobuf:"varint,2,opt,name=quantity"`
+	xxx_hidden_RemainingStock int64                  `protobuf:"varint,3,opt,name=remaining_stock,json=remainingStock"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *PurchaseProductResponse) Reset() {
+	*x = PurchaseProductResponse{}
+	mi := &file_catalog_v1_product_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PurchaseProductResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PurchaseProductResponse) ProtoMessage() {}
+
+func (x *PurchaseProductResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_catalog_v1_product_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PurchaseProductResponse) GetProductId() string {
+	if x != nil {
+		return x.xxx_hidden_ProductId
+	}
+	return ""
+}
+
+func (x *PurchaseProductResponse) GetQuantity() int64 {
+	if x != nil {
+		return x.xxx_hidden_Quantity
+	}
+	return 0
+}
+
+func (x *PurchaseProductResponse) GetRemainingStock() int64 {
+	if x != nil {
+		return x.xxx_hidden_RemainingStock
+	}
+	return 0
+}
+
+func (x *PurchaseProductResponse) SetProductId(v string) {
+	x.xxx_hidden_ProductId = v
+}
+
+func (x *PurchaseProductResponse) SetQuantity(v int64) {
+	x.xxx_hidden_Quantity = v
+}
+
+func (x *PurchaseProductResponse) SetRemainingStock(v int64) {
+	x.xxx_hidden_RemainingStock = v
+}
+
+type PurchaseProductResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	ProductId      string
+	Quantity       int64
+	RemainingStock int64
+}
+
+func (b0 PurchaseProductResponse_builder) Build() *PurchaseProductResponse {
+	m0 := &PurchaseProductResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_ProductId = b.ProductId
+	x.xxx_hidden_Quantity = b.Quantity
+	x.xxx_hidden_RemainingStock = b.RemainingStock
+	return m0
+}
+
 var File_catalog_v1_product_proto protoreflect.FileDescriptor
 
 const file_catalog_v1_product_proto_rawDesc = "" +
@@ -880,14 +1064,16 @@ const file_catalog_v1_product_proto_rawDesc = "" +
 	"catalog.v1\"F\n" +
 	"\x05Money\x12!\n" +
 	"\fminor_amount\x18\x01 \x01(\x03R\vminorAmount\x12\x1a\n" +
-	"\bcurrency\x18\x02 \x01(\tR\bcurrency\"V\n" +
+	"\bcurrency\x18\x02 \x01(\tR\bcurrency\"l\n" +
 	"\aProduct\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12'\n" +
-	"\x05price\x18\x03 \x01(\v2\x11.catalog.v1.MoneyR\x05price\"S\n" +
+	"\x05price\x18\x03 \x01(\v2\x11.catalog.v1.MoneyR\x05price\x12\x14\n" +
+	"\x05stock\x18\x04 \x01(\x03R\x05stock\"i\n" +
 	"\x14CreateProductRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12'\n" +
-	"\x05price\x18\x02 \x01(\v2\x11.catalog.v1.MoneyR\x05price\"F\n" +
+	"\x05price\x18\x02 \x01(\v2\x11.catalog.v1.MoneyR\x05price\x12\x14\n" +
+	"\x05stock\x18\x03 \x01(\x03R\x05stock\"F\n" +
 	"\x15CreateProductResponse\x12-\n" +
 	"\aproduct\x18\x01 \x01(\v2\x13.catalog.v1.ProductR\aproduct\"#\n" +
 	"\x11GetProductRequest\x12\x0e\n" +
@@ -909,32 +1095,43 @@ const file_catalog_v1_product_proto_rawDesc = "" +
 	"\aproduct\x18\x01 \x01(\v2\x13.catalog.v1.ProductR\aproduct\"&\n" +
 	"\x14DeleteProductRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"\x17\n" +
-	"\x15DeleteProductResponse2\xb2\x03\n" +
+	"\x15DeleteProductResponse\"D\n" +
+	"\x16PurchaseProductRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1a\n" +
+	"\bquantity\x18\x02 \x01(\x03R\bquantity\"}\n" +
+	"\x17PurchaseProductResponse\x12\x1d\n" +
+	"\n" +
+	"product_id\x18\x01 \x01(\tR\tproductId\x12\x1a\n" +
+	"\bquantity\x18\x02 \x01(\x03R\bquantity\x12'\n" +
+	"\x0fremaining_stock\x18\x03 \x01(\x03R\x0eremainingStock2\x8e\x04\n" +
 	"\x0eProductService\x12T\n" +
 	"\rCreateProduct\x12 .catalog.v1.CreateProductRequest\x1a!.catalog.v1.CreateProductResponse\x12K\n" +
 	"\n" +
 	"GetProduct\x12\x1d.catalog.v1.GetProductRequest\x1a\x1e.catalog.v1.GetProductResponse\x12Q\n" +
 	"\fListProducts\x12\x1f.catalog.v1.ListProductsRequest\x1a .catalog.v1.ListProductsResponse\x12T\n" +
 	"\rUpdateProduct\x12 .catalog.v1.UpdateProductRequest\x1a!.catalog.v1.UpdateProductResponse\x12T\n" +
-	"\rDeleteProduct\x12 .catalog.v1.DeleteProductRequest\x1a!.catalog.v1.DeleteProductResponseB\xa6\x01\n" +
+	"\rDeleteProduct\x12 .catalog.v1.DeleteProductRequest\x1a!.catalog.v1.DeleteProductResponse\x12Z\n" +
+	"\x0fPurchaseProduct\x12\".catalog.v1.PurchaseProductRequest\x1a#.catalog.v1.PurchaseProductResponseB\xa6\x01\n" +
 	"\x0ecom.catalog.v1B\fProductProtoP\x01Z8github.com/alkmc/storefront/api/gen/catalog/v1;catalogv1\xa2\x02\x03CXX\xaa\x02\n" +
 	"Catalog.V1\xca\x02\n" +
 	"Catalog\\V1\xe2\x02\x16Catalog\\V1\\GPBMetadata\xea\x02\vCatalog::V1\x92\x03\x02\b\x02b\beditionsp\xe9\a"
 
-var file_catalog_v1_product_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_catalog_v1_product_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_catalog_v1_product_proto_goTypes = []any{
-	(*Money)(nil),                 // 0: catalog.v1.Money
-	(*Product)(nil),               // 1: catalog.v1.Product
-	(*CreateProductRequest)(nil),  // 2: catalog.v1.CreateProductRequest
-	(*CreateProductResponse)(nil), // 3: catalog.v1.CreateProductResponse
-	(*GetProductRequest)(nil),     // 4: catalog.v1.GetProductRequest
-	(*GetProductResponse)(nil),    // 5: catalog.v1.GetProductResponse
-	(*ListProductsRequest)(nil),   // 6: catalog.v1.ListProductsRequest
-	(*ListProductsResponse)(nil),  // 7: catalog.v1.ListProductsResponse
-	(*UpdateProductRequest)(nil),  // 8: catalog.v1.UpdateProductRequest
-	(*UpdateProductResponse)(nil), // 9: catalog.v1.UpdateProductResponse
-	(*DeleteProductRequest)(nil),  // 10: catalog.v1.DeleteProductRequest
-	(*DeleteProductResponse)(nil), // 11: catalog.v1.DeleteProductResponse
+	(*Money)(nil),                   // 0: catalog.v1.Money
+	(*Product)(nil),                 // 1: catalog.v1.Product
+	(*CreateProductRequest)(nil),    // 2: catalog.v1.CreateProductRequest
+	(*CreateProductResponse)(nil),   // 3: catalog.v1.CreateProductResponse
+	(*GetProductRequest)(nil),       // 4: catalog.v1.GetProductRequest
+	(*GetProductResponse)(nil),      // 5: catalog.v1.GetProductResponse
+	(*ListProductsRequest)(nil),     // 6: catalog.v1.ListProductsRequest
+	(*ListProductsResponse)(nil),    // 7: catalog.v1.ListProductsResponse
+	(*UpdateProductRequest)(nil),    // 8: catalog.v1.UpdateProductRequest
+	(*UpdateProductResponse)(nil),   // 9: catalog.v1.UpdateProductResponse
+	(*DeleteProductRequest)(nil),    // 10: catalog.v1.DeleteProductRequest
+	(*DeleteProductResponse)(nil),   // 11: catalog.v1.DeleteProductResponse
+	(*PurchaseProductRequest)(nil),  // 12: catalog.v1.PurchaseProductRequest
+	(*PurchaseProductResponse)(nil), // 13: catalog.v1.PurchaseProductResponse
 }
 var file_catalog_v1_product_proto_depIdxs = []int32{
 	0,  // 0: catalog.v1.Product.price:type_name -> catalog.v1.Money
@@ -949,13 +1146,15 @@ var file_catalog_v1_product_proto_depIdxs = []int32{
 	6,  // 9: catalog.v1.ProductService.ListProducts:input_type -> catalog.v1.ListProductsRequest
 	8,  // 10: catalog.v1.ProductService.UpdateProduct:input_type -> catalog.v1.UpdateProductRequest
 	10, // 11: catalog.v1.ProductService.DeleteProduct:input_type -> catalog.v1.DeleteProductRequest
-	3,  // 12: catalog.v1.ProductService.CreateProduct:output_type -> catalog.v1.CreateProductResponse
-	5,  // 13: catalog.v1.ProductService.GetProduct:output_type -> catalog.v1.GetProductResponse
-	7,  // 14: catalog.v1.ProductService.ListProducts:output_type -> catalog.v1.ListProductsResponse
-	9,  // 15: catalog.v1.ProductService.UpdateProduct:output_type -> catalog.v1.UpdateProductResponse
-	11, // 16: catalog.v1.ProductService.DeleteProduct:output_type -> catalog.v1.DeleteProductResponse
-	12, // [12:17] is the sub-list for method output_type
-	7,  // [7:12] is the sub-list for method input_type
+	12, // 12: catalog.v1.ProductService.PurchaseProduct:input_type -> catalog.v1.PurchaseProductRequest
+	3,  // 13: catalog.v1.ProductService.CreateProduct:output_type -> catalog.v1.CreateProductResponse
+	5,  // 14: catalog.v1.ProductService.GetProduct:output_type -> catalog.v1.GetProductResponse
+	7,  // 15: catalog.v1.ProductService.ListProducts:output_type -> catalog.v1.ListProductsResponse
+	9,  // 16: catalog.v1.ProductService.UpdateProduct:output_type -> catalog.v1.UpdateProductResponse
+	11, // 17: catalog.v1.ProductService.DeleteProduct:output_type -> catalog.v1.DeleteProductResponse
+	13, // 18: catalog.v1.ProductService.PurchaseProduct:output_type -> catalog.v1.PurchaseProductResponse
+	13, // [13:19] is the sub-list for method output_type
+	7,  // [7:13] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
@@ -972,7 +1171,7 @@ func file_catalog_v1_product_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_catalog_v1_product_proto_rawDesc), len(file_catalog_v1_product_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/catalog/v1/product_grpc.pb.go
+++ b/api/gen/catalog/v1/product_grpc.pb.go
@@ -19,11 +19,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ProductService_CreateProduct_FullMethodName = "/catalog.v1.ProductService/CreateProduct"
-	ProductService_GetProduct_FullMethodName    = "/catalog.v1.ProductService/GetProduct"
-	ProductService_ListProducts_FullMethodName  = "/catalog.v1.ProductService/ListProducts"
-	ProductService_UpdateProduct_FullMethodName = "/catalog.v1.ProductService/UpdateProduct"
-	ProductService_DeleteProduct_FullMethodName = "/catalog.v1.ProductService/DeleteProduct"
+	ProductService_CreateProduct_FullMethodName   = "/catalog.v1.ProductService/CreateProduct"
+	ProductService_GetProduct_FullMethodName      = "/catalog.v1.ProductService/GetProduct"
+	ProductService_ListProducts_FullMethodName    = "/catalog.v1.ProductService/ListProducts"
+	ProductService_UpdateProduct_FullMethodName   = "/catalog.v1.ProductService/UpdateProduct"
+	ProductService_DeleteProduct_FullMethodName   = "/catalog.v1.ProductService/DeleteProduct"
+	ProductService_PurchaseProduct_FullMethodName = "/catalog.v1.ProductService/PurchaseProduct"
 )
 
 // ProductServiceClient is the client API for ProductService service.
@@ -42,6 +43,8 @@ type ProductServiceClient interface {
 	UpdateProduct(ctx context.Context, in *UpdateProductRequest, opts ...grpc.CallOption) (*UpdateProductResponse, error)
 	// DeleteProduct removes a product by id.
 	DeleteProduct(ctx context.Context, in *DeleteProductRequest, opts ...grpc.CallOption) (*DeleteProductResponse, error)
+	// PurchaseProduct decrements stock and returns the remaining amount.
+	PurchaseProduct(ctx context.Context, in *PurchaseProductRequest, opts ...grpc.CallOption) (*PurchaseProductResponse, error)
 }
 
 type productServiceClient struct {
@@ -102,6 +105,16 @@ func (c *productServiceClient) DeleteProduct(ctx context.Context, in *DeleteProd
 	return out, nil
 }
 
+func (c *productServiceClient) PurchaseProduct(ctx context.Context, in *PurchaseProductRequest, opts ...grpc.CallOption) (*PurchaseProductResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PurchaseProductResponse)
+	err := c.cc.Invoke(ctx, ProductService_PurchaseProduct_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ProductServiceServer is the server API for ProductService service.
 // All implementations must embed UnimplementedProductServiceServer
 // for forward compatibility.
@@ -118,6 +131,8 @@ type ProductServiceServer interface {
 	UpdateProduct(context.Context, *UpdateProductRequest) (*UpdateProductResponse, error)
 	// DeleteProduct removes a product by id.
 	DeleteProduct(context.Context, *DeleteProductRequest) (*DeleteProductResponse, error)
+	// PurchaseProduct decrements stock and returns the remaining amount.
+	PurchaseProduct(context.Context, *PurchaseProductRequest) (*PurchaseProductResponse, error)
 	mustEmbedUnimplementedProductServiceServer()
 }
 
@@ -142,6 +157,9 @@ func (UnimplementedProductServiceServer) UpdateProduct(context.Context, *UpdateP
 }
 func (UnimplementedProductServiceServer) DeleteProduct(context.Context, *DeleteProductRequest) (*DeleteProductResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteProduct not implemented")
+}
+func (UnimplementedProductServiceServer) PurchaseProduct(context.Context, *PurchaseProductRequest) (*PurchaseProductResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PurchaseProduct not implemented")
 }
 func (UnimplementedProductServiceServer) mustEmbedUnimplementedProductServiceServer() {}
 func (UnimplementedProductServiceServer) testEmbeddedByValue()                        {}
@@ -254,6 +272,24 @@ func _ProductService_DeleteProduct_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProductService_PurchaseProduct_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PurchaseProductRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProductServiceServer).PurchaseProduct(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ProductService_PurchaseProduct_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProductServiceServer).PurchaseProduct(ctx, req.(*PurchaseProductRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ProductService_ServiceDesc is the grpc.ServiceDesc for ProductService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -280,6 +316,10 @@ var ProductService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteProduct",
 			Handler:    _ProductService_DeleteProduct_Handler,
+		},
+		{
+			MethodName: "PurchaseProduct",
+			Handler:    _ProductService_PurchaseProduct_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/catalog/v1/product.proto
+++ b/api/proto/catalog/v1/product.proto
@@ -16,6 +16,8 @@ service ProductService {
   rpc UpdateProduct(UpdateProductRequest) returns (UpdateProductResponse);
   // DeleteProduct removes a product by id.
   rpc DeleteProduct(DeleteProductRequest) returns (DeleteProductResponse);
+  // PurchaseProduct decrements stock and returns the remaining amount.
+  rpc PurchaseProduct(PurchaseProductRequest) returns (PurchaseProductResponse);
 }
 
 // Money is an amount in the smallest unit of an ISO 4217 currency.
@@ -29,11 +31,13 @@ message Product {
   string id = 1;
   string name = 2;
   Money price = 3;
+  int64 stock = 4;
 }
 
 message CreateProductRequest {
   string name = 1;
   Money price = 2;
+  int64 stock = 3;
 }
 
 message CreateProductResponse {
@@ -73,3 +77,14 @@ message DeleteProductRequest {
 }
 
 message DeleteProductResponse {}
+
+message PurchaseProductRequest {
+  string id = 1;
+  int64 quantity = 2;
+}
+
+message PurchaseProductResponse {
+  string product_id = 1;
+  int64 quantity = 2;
+  int64 remaining_stock = 3;
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,9 +17,11 @@ var ErrCacheMiss = errors.New("cache: key not found")
 
 type (
 	cacheEntry struct {
-		ID    string     `json:"id"`
-		Name  string     `json:"name"`
-		Price moneyEntry `json:"price"`
+		ID      string     `json:"id"`
+		Name    string     `json:"name"`
+		Stock   int64      `json:"stock"`
+		Version int64      `json:"version"`
+		Price   moneyEntry `json:"price"`
 	}
 	moneyEntry struct {
 		MinorAmount int64           `json:"minorAmount"`
@@ -38,8 +40,10 @@ func New(client rueidis.Client, ttl time.Duration) *Redis {
 
 func (r *Redis) Set(ctx context.Context, key string, value domain.Product) error {
 	data, err := json.Marshal(cacheEntry{
-		ID:   value.ID.String(),
-		Name: value.Name,
+		ID:      value.ID.String(),
+		Name:    value.Name,
+		Stock:   value.Stock,
+		Version: value.Version,
 		Price: moneyEntry{
 			MinorAmount: value.Price.MinorAmount,
 			Currency:    value.Price.Currency,
@@ -78,8 +82,10 @@ func (r *Redis) Get(ctx context.Context, key string) (domain.Product, error) {
 		return domain.Product{}, fmt.Errorf("parse cached id for key %q: %w", key, err)
 	}
 	return domain.Product{
-		ID:   id,
-		Name: e.Name,
+		ID:      id,
+		Name:    e.Name,
+		Stock:   e.Stock,
+		Version: e.Version,
 		Price: domain.Money{
 			MinorAmount: e.Price.MinorAmount,
 			Currency:    e.Price.Currency,

--- a/internal/domain/product.go
+++ b/internal/domain/product.go
@@ -11,14 +11,18 @@ var (
 	ErrNotFound = errors.New("domain: not found")
 	// ErrUnavailable signals that a backing dependency is temporarily unavailable.
 	ErrUnavailable = errors.New("domain: dependency unavailable")
+	// ErrInsufficientStock signals a purchase for more units than are in stock.
+	ErrInsufficientStock = errors.New("domain: insufficient stock")
 )
 
 type (
 	// Product represents a purchasable item in the system
 	Product struct {
-		ID    uuid.UUID
-		Name  string
-		Price Money
+		ID      uuid.UUID
+		Name    string
+		Price   Money
+		Stock   int64
+		Version int64
 	}
 	// ProductPage is a single keyset page
 	ProductPage struct {
@@ -27,6 +31,18 @@ type (
 	}
 )
 
+const (
+	minPurchaseQuantity = 1
+	// maxPurchaseQuantity is an arbitrary per-request sanity cap.
+	// It rejects absurd quantities as invalid input rather than as insufficient stock.
+	maxPurchaseQuantity = 10000
+)
+
+// ValidPurchaseQuantity reports whether qty falls within the purchasable range.
+func ValidPurchaseQuantity(qty int64) bool {
+	return qty >= minPurchaseQuantity && qty <= maxPurchaseQuantity
+}
+
 // Validate ensures the product meets basic business rules before processing
 func (p *Product) Validate() error {
 	if p.Name == "" {
@@ -34,6 +50,9 @@ func (p *Product) Validate() error {
 	}
 	if err := p.Price.Validate(); err != nil {
 		return err
+	}
+	if p.Stock < 0 {
+		return errors.New("the product stock must not be negative")
 	}
 	return nil
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -18,8 +18,9 @@ type (
 		Save(context.Context, domain.Product) (domain.Product, error)
 		FindByID(context.Context, uuid.UUID) (domain.Product, error)
 		FindAll(context.Context, uuid.NullUUID, int) (domain.ProductPage, error)
-		Update(context.Context, domain.Product) error
+		Update(context.Context, domain.Product) (domain.Product, error)
 		Delete(context.Context, uuid.UUID) error
+		Purchase(context.Context, uuid.UUID, int64) (domain.Product, error)
 	}
 	cacher interface {
 		Set(context.Context, string, domain.Product) error
@@ -101,15 +102,16 @@ func (s *Service) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
 	return s.store.FindAll(ctx, cursor, limit)
 }
 
-func (s *Service) Update(ctx context.Context, p domain.Product) error {
-	if err := s.store.Update(ctx, p); err != nil {
-		return err
+func (s *Service) Update(ctx context.Context, p domain.Product) (domain.Product, error) {
+	updated, err := s.store.Update(ctx, p)
+	if err != nil {
+		return domain.Product{}, err
 	}
 	key := p.ID.String()
 	if err := s.cache.Invalidate(ctx, key); err != nil {
 		s.logger.Warn("cache invalidate failed", slog.Any("error", err), slog.String("key", key))
 	}
-	return nil
+	return updated, nil
 }
 
 func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
@@ -121,4 +123,16 @@ func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		s.logger.Warn("cache invalidate failed", slog.Any("error", err), slog.String("key", key))
 	}
 	return nil
+}
+
+func (s *Service) Purchase(ctx context.Context, id uuid.UUID, qty int64) (domain.Product, error) {
+	p, err := s.store.Purchase(ctx, id, qty)
+	if err != nil {
+		return domain.Product{}, err
+	}
+	key := id.String()
+	if err := s.cache.Invalidate(ctx, key); err != nil {
+		s.logger.Warn("cache invalidate failed", slog.Any("error", err), slog.String("key", key))
+	}
+	return p, nil
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -210,8 +210,8 @@ func TestService_Update(t *testing.T) {
 			name:    "success",
 			product: domain.Product{Name: "Update", Price: testMoney(1000)},
 			spySetup: func(s *SpyStore) {
-				s.UpdateFn = func(_ context.Context, _ domain.Product) error {
-					return nil
+				s.UpdateFn = func(_ context.Context, p domain.Product) (domain.Product, error) {
+					return p, nil
 				}
 			},
 			wantErr: false,
@@ -224,7 +224,7 @@ func TestService_Update(t *testing.T) {
 			tt.spySetup(spyStore)
 			srv := newTestService(spyStore)
 
-			err := srv.Update(ctx, tt.product)
+			_, err := srv.Update(ctx, tt.product)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")
@@ -277,6 +277,25 @@ func TestService_Delete(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestService_Purchase(t *testing.T) {
+	ctx := t.Context()
+	id := uuid.Must(uuid.NewV7())
+
+	spyStore := new(SpyStore{})
+	spyStore.PurchaseFn = func(_ context.Context, _ uuid.UUID, _ int64) (domain.Product, error) {
+		return domain.Product{ID: id, Stock: 3}, nil
+	}
+	srv := newTestService(spyStore)
+
+	p, err := srv.Purchase(ctx, id, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Stock != 3 {
+		t.Errorf("got remaining stock %d, want 3", p.Stock)
 	}
 }
 

--- a/internal/service/spy_stub_test.go
+++ b/internal/service/spy_stub_test.go
@@ -26,8 +26,9 @@ type SpyStore struct {
 	SaveFn     func(context.Context, domain.Product) (domain.Product, error)
 	FindByIDFn func(context.Context, uuid.UUID) (domain.Product, error)
 	FindAllFn  func(context.Context, uuid.NullUUID, int) (domain.ProductPage, error)
-	UpdateFn   func(context.Context, domain.Product) error
+	UpdateFn   func(context.Context, domain.Product) (domain.Product, error)
 	DeleteFn   func(context.Context, uuid.UUID) error
+	PurchaseFn func(context.Context, uuid.UUID, int64) (domain.Product, error)
 }
 
 func (s *SpyStore) Save(ctx context.Context, p domain.Product) (domain.Product, error) {
@@ -43,11 +44,11 @@ func (s *SpyStore) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
 	return s.FindAllFn(ctx, cursor, limit)
 }
 
-func (s *SpyStore) Update(ctx context.Context, p domain.Product) error {
+func (s *SpyStore) Update(ctx context.Context, p domain.Product) (domain.Product, error) {
 	if s.UpdateFn != nil {
 		return s.UpdateFn(ctx, p)
 	}
-	return nil
+	return domain.Product{}, nil
 }
 
 func (s *SpyStore) Delete(ctx context.Context, id uuid.UUID) error {
@@ -55,4 +56,11 @@ func (s *SpyStore) Delete(ctx context.Context, id uuid.UUID) error {
 		return s.DeleteFn(ctx, id)
 	}
 	return nil
+}
+
+func (s *SpyStore) Purchase(ctx context.Context, id uuid.UUID, qty int64) (domain.Product, error) {
+	if s.PurchaseFn != nil {
+		return s.PurchaseFn(ctx, id, qty)
+	}
+	return domain.Product{}, nil
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -55,16 +55,15 @@ func (pg *Postgres) FindByID(
 	row := pg.pool.QueryRow(ctx, queryGetByID, id)
 
 	var p domain.Product
-	var currency string
 	if err := row.Scan(
-		&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version,
+		&p.ID, &p.Name, &p.Price.MinorAmount, &p.Price.Currency, &p.Stock, &p.Version,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.Product{}, domain.ErrNotFound
 		}
 		return domain.Product{}, mapDBError(err)
 	}
-	p.Price.Currency = domain.Currency(currency)
+
 	return p, nil
 }
 
@@ -90,13 +89,11 @@ func (pg *Postgres) FindAll(
 	products := make([]domain.Product, 0, limit+1)
 	for rows.Next() {
 		var p domain.Product
-		var currency string
 		if err := rows.Scan(
-			&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version,
+			&p.ID, &p.Name, &p.Price.MinorAmount, &p.Price.Currency, &p.Stock, &p.Version,
 		); err != nil {
 			return domain.ProductPage{}, mapDBError(err)
 		}
-		p.Price.Currency = domain.Currency(currency)
 		products = append(products, p)
 	}
 
@@ -110,17 +107,16 @@ func (pg *Postgres) FindAll(
 func (pg *Postgres) Update(
 	ctx context.Context, p domain.Product,
 ) (domain.Product, error) {
-	var currency string
 	err := pg.pool.QueryRow(
 		ctx, queryUpdate, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency),
-	).Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version)
+	).Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &p.Price.Currency, &p.Stock, &p.Version)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.Product{}, domain.ErrNotFound
 		}
 		return domain.Product{}, mapDBError(err)
 	}
-	p.Price.Currency = domain.Currency(currency)
+
 	return p, nil
 }
 
@@ -132,6 +128,7 @@ func (pg *Postgres) Delete(ctx context.Context, id uuid.UUID) error {
 	if res.RowsAffected() == 0 {
 		return domain.ErrNotFound
 	}
+
 	return nil
 }
 
@@ -148,9 +145,8 @@ func (pg *Postgres) Purchase(
 	}()
 
 	var p domain.Product
-	var currency string
 	if err := tx.QueryRow(ctx, queryPurchase, id, qty).Scan(
-		&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version,
+		&p.ID, &p.Name, &p.Price.MinorAmount, &p.Price.Currency, &p.Stock, &p.Version,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.Product{}, purchaseNoRowError(ctx, tx, id)
@@ -158,11 +154,10 @@ func (pg *Postgres) Purchase(
 		return domain.Product{}, mapDBError(err)
 	}
 
-	p.Price.Currency = domain.Currency(currency)
-
 	if err := tx.Commit(ctx); err != nil {
 		return domain.Product{}, mapDBError(err)
 	}
+
 	return p, nil
 }
 
@@ -175,6 +170,7 @@ func purchaseNoRowError(ctx context.Context, tx pgx.Tx, id uuid.UUID) error {
 	if !exists {
 		return domain.ErrNotFound
 	}
+
 	return domain.ErrInsufficientStock
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -37,21 +37,28 @@ func (pg *Postgres) Ping(ctx context.Context) error {
 	return pg.pool.Ping(ctx)
 }
 
-func (pg *Postgres) Save(ctx context.Context, p domain.Product) (domain.Product, error) {
-	if _, err := pg.pool.Exec(
-		ctx, queryInsert, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency),
-	); err != nil {
+func (pg *Postgres) Save(
+	ctx context.Context, p domain.Product,
+) (domain.Product, error) {
+	row := pg.pool.QueryRow(
+		ctx, queryInsert, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency), p.Stock,
+	)
+	if err := row.Scan(&p.Version); err != nil {
 		return domain.Product{}, mapDBError(err)
 	}
 	return p, nil
 }
 
-func (pg *Postgres) FindByID(ctx context.Context, id uuid.UUID) (domain.Product, error) {
+func (pg *Postgres) FindByID(
+	ctx context.Context, id uuid.UUID,
+) (domain.Product, error) {
 	row := pg.pool.QueryRow(ctx, queryGetByID, id)
 
 	var p domain.Product
 	var currency string
-	if err := row.Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency); err != nil {
+	if err := row.Scan(
+		&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version,
+	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.Product{}, domain.ErrNotFound
 		}
@@ -61,7 +68,8 @@ func (pg *Postgres) FindByID(ctx context.Context, id uuid.UUID) (domain.Product,
 	return p, nil
 }
 
-func (pg *Postgres) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int,
+func (pg *Postgres) FindAll(
+	ctx context.Context, cursor uuid.NullUUID, limit int,
 ) (domain.ProductPage, error) {
 	var (
 		rows      pgx.Rows
@@ -83,7 +91,9 @@ func (pg *Postgres) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int
 	for rows.Next() {
 		var p domain.Product
 		var currency string
-		if err := rows.Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency); err != nil {
+		if err := rows.Scan(
+			&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version,
+		); err != nil {
 			return domain.ProductPage{}, mapDBError(err)
 		}
 		p.Price.Currency = domain.Currency(currency)
@@ -97,15 +107,21 @@ func (pg *Postgres) FindAll(ctx context.Context, cursor uuid.NullUUID, limit int
 	return productPage(products, limit), nil
 }
 
-func (pg *Postgres) Update(ctx context.Context, p domain.Product) error {
-	res, err := pg.pool.Exec(ctx, queryUpdate, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency))
+func (pg *Postgres) Update(
+	ctx context.Context, p domain.Product,
+) (domain.Product, error) {
+	var currency string
+	err := pg.pool.QueryRow(
+		ctx, queryUpdate, p.ID, p.Name, p.Price.MinorAmount, string(p.Price.Currency),
+	).Scan(&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version)
 	if err != nil {
-		return mapDBError(err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Product{}, domain.ErrNotFound
+		}
+		return domain.Product{}, mapDBError(err)
 	}
-	if res.RowsAffected() == 0 {
-		return domain.ErrNotFound
-	}
-	return nil
+	p.Price.Currency = domain.Currency(currency)
+	return p, nil
 }
 
 func (pg *Postgres) Delete(ctx context.Context, id uuid.UUID) error {
@@ -117,6 +133,49 @@ func (pg *Postgres) Delete(ctx context.Context, id uuid.UUID) error {
 		return domain.ErrNotFound
 	}
 	return nil
+}
+
+// Purchase atomically decrements stock in an explicit tx.
+func (pg *Postgres) Purchase(
+	ctx context.Context, id uuid.UUID, qty int64,
+) (domain.Product, error) {
+	tx, err := pg.pool.Begin(ctx)
+	if err != nil {
+		return domain.Product{}, mapDBError(err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var p domain.Product
+	var currency string
+	if err := tx.QueryRow(ctx, queryPurchase, id, qty).Scan(
+		&p.ID, &p.Name, &p.Price.MinorAmount, &currency, &p.Stock, &p.Version,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Product{}, purchaseNoRowError(ctx, tx, id)
+		}
+		return domain.Product{}, mapDBError(err)
+	}
+
+	p.Price.Currency = domain.Currency(currency)
+
+	if err := tx.Commit(ctx); err != nil {
+		return domain.Product{}, mapDBError(err)
+	}
+	return p, nil
+}
+
+// purchaseNoRowError tells a missing product apart from insufficient stock.
+func purchaseNoRowError(ctx context.Context, tx pgx.Tx, id uuid.UUID) error {
+	var exists bool
+	if err := tx.QueryRow(ctx, queryProductExists, id).Scan(&exists); err != nil {
+		return mapDBError(err)
+	}
+	if !exists {
+		return domain.ErrNotFound
+	}
+	return domain.ErrInsufficientStock
 }
 
 // mapDBError tags connection-class failures as domain.ErrUnavailable.

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -479,6 +479,7 @@ func TestPostgres_Purchase_OversellInvariant(t *testing.T) {
 	const (
 		initialStock     = 3
 		concurrentBuyers = 50
+		deniedBuyers     = concurrentBuyers - initialStock
 	)
 
 	id := uuid.Must(uuid.NewV7())
@@ -514,8 +515,8 @@ func TestPostgres_Purchase_OversellInvariant(t *testing.T) {
 	if got := successes.Load(); got != initialStock {
 		t.Errorf("got %d successful purchases, want %d", got, initialStock)
 	}
-	if got := insufficient.Load(); got != concurrentBuyers-initialStock {
-		t.Errorf("got %d insufficient-stock errors, want %d", got, concurrentBuyers-initialStock)
+	if got := insufficient.Load(); got != deniedBuyers {
+		t.Errorf("got %d insufficient-stock errors, want %d", got, deniedBuyers)
 	}
 
 	final, err := repo.FindByID(ctx, id)

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -5,6 +5,8 @@ package store
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -290,7 +292,7 @@ func TestPostgres_Update(t *testing.T) {
 
 	id := uuid.Must(uuid.NewV7())
 	if _, err := repo.Save(
-		ctx, domain.Product{ID: id, Name: "OldName", Price: testMoney(1000)},
+		ctx, domain.Product{ID: id, Name: "OldName", Price: testMoney(1000), Stock: 5},
 	); err != nil {
 		t.Fatalf("failed to save product: %v", err)
 	}
@@ -321,7 +323,7 @@ func TestPostgres_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := repo.Update(ctx, tt.product)
+			updated, err := repo.Update(ctx, tt.product)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")
@@ -335,12 +337,14 @@ func TestPostgres_Update(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			p, err := repo.FindByID(ctx, tt.product.ID)
-			if err != nil {
-				t.Fatalf("failed to fetch updated product: %v", err)
+			if updated.Name != tt.product.Name || updated.Price != tt.product.Price {
+				t.Errorf("update failed: got %+v", updated)
 			}
-			if p.Name != tt.product.Name || p.Price != tt.product.Price {
-				t.Errorf("update failed: got %+v", p)
+			if updated.Stock != 5 {
+				t.Errorf("stock not preserved by update: got %d, want 5", updated.Stock)
+			}
+			if updated.Version != 2 {
+				t.Errorf("version not bumped: got %d, want 2", updated.Version)
 			}
 		})
 	}
@@ -392,6 +396,138 @@ func TestPostgres_Delete(t *testing.T) {
 				t.Fatalf("expected domain.ErrNotFound after deletion, got %v", err)
 			}
 		})
+	}
+}
+
+func TestPostgres_Purchase(t *testing.T) {
+	repo, cleanup := setupTestContainerDB(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	tests := []struct {
+		name          string
+		seedStock     int64
+		qty           int64
+		wantErrIs     error
+		wantRemaining int64
+		wantVersion   int64
+	}{
+		{
+			name:          "success decrements stock and bumps version",
+			seedStock:     5,
+			qty:           2,
+			wantRemaining: 3,
+			wantVersion:   2,
+		},
+		{
+			name:      "insufficient stock",
+			seedStock: 1,
+			qty:       2,
+			wantErrIs: domain.ErrInsufficientStock,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := uuid.Must(uuid.NewV7())
+			if _, err := repo.Save(
+				ctx, domain.Product{ID: id, Name: "Widget", Price: testMoney(1000), Stock: tt.seedStock},
+			); err != nil {
+				t.Fatalf("failed to seed product: %v", err)
+			}
+
+			p, err := repo.Purchase(ctx, id, tt.qty)
+			if tt.wantErrIs != nil {
+				if !errors.Is(err, tt.wantErrIs) {
+					t.Fatalf("got %v, want %v", err, tt.wantErrIs)
+				}
+				got, err := repo.FindByID(ctx, id)
+				if err != nil {
+					t.Fatalf("failed to reload product: %v", err)
+				}
+				if got.Stock != tt.seedStock {
+					t.Errorf("stock changed on failed purchase: got %d, want %d", got.Stock, tt.seedStock)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Stock != tt.wantRemaining {
+				t.Errorf("got remaining stock %d, want %d", p.Stock, tt.wantRemaining)
+			}
+			if p.Version != tt.wantVersion {
+				t.Errorf("got version %d, want %d", p.Version, tt.wantVersion)
+			}
+		})
+	}
+
+	t.Run("non-existing product", func(t *testing.T) {
+		_, err := repo.Purchase(ctx, uuid.Must(uuid.NewV7()), 1)
+		if !errors.Is(err, domain.ErrNotFound) {
+			t.Fatalf("got %v, want domain.ErrNotFound", err)
+		}
+	})
+}
+
+func TestPostgres_Purchase_OversellInvariant(t *testing.T) {
+	repo, cleanup := setupTestContainerDB(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	const (
+		initialStock = 3
+		goroutines   = 50
+	)
+
+	id := uuid.Must(uuid.NewV7())
+	if _, err := repo.Save(
+		ctx, domain.Product{ID: id, Name: "Widget", Price: testMoney(1000), Stock: initialStock},
+	); err != nil {
+		t.Fatalf("failed to seed product: %v", err)
+	}
+
+	var (
+		wg           sync.WaitGroup
+		successes    atomic.Int64
+		insufficient atomic.Int64
+	)
+	start := make(chan struct{})
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			_, err := repo.Purchase(ctx, id, 1)
+			switch {
+			case err == nil:
+				successes.Add(1)
+			case errors.Is(err, domain.ErrInsufficientStock):
+				insufficient.Add(1)
+			default:
+				t.Errorf("unexpected purchase error: %v", err)
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	if got := successes.Load(); got != initialStock {
+		t.Errorf("got %d successful purchases, want %d", got, initialStock)
+	}
+	if got := insufficient.Load(); got != goroutines-initialStock {
+		t.Errorf("got %d insufficient-stock errors, want %d", got, goroutines-initialStock)
+	}
+
+	final, err := repo.FindByID(ctx, id)
+	if err != nil {
+		t.Fatalf("failed to reload product: %v", err)
+	}
+	if final.Stock != 0 {
+		t.Errorf("got final stock %d, want 0", final.Stock)
+	}
+	// version starts at 1 (DEFAULT) and increments once per successful purchase.
+	if want := int64(1 + initialStock); final.Version != want {
+		t.Errorf("got version %d, want %d", final.Version, want)
 	}
 }
 

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -477,8 +477,8 @@ func TestPostgres_Purchase_OversellInvariant(t *testing.T) {
 	ctx := t.Context()
 
 	const (
-		initialStock = 3
-		goroutines   = 50
+		initialStock     = 3
+		concurrentBuyers = 50
 	)
 
 	id := uuid.Must(uuid.NewV7())
@@ -494,7 +494,7 @@ func TestPostgres_Purchase_OversellInvariant(t *testing.T) {
 		insufficient atomic.Int64
 	)
 	start := make(chan struct{})
-	for range goroutines {
+	for range concurrentBuyers {
 		wg.Go(func() {
 			<-start
 			_, err := repo.Purchase(ctx, id, 1)
@@ -514,8 +514,8 @@ func TestPostgres_Purchase_OversellInvariant(t *testing.T) {
 	if got := successes.Load(); got != initialStock {
 		t.Errorf("got %d successful purchases, want %d", got, initialStock)
 	}
-	if got := insufficient.Load(); got != goroutines-initialStock {
-		t.Errorf("got %d insufficient-stock errors, want %d", got, goroutines-initialStock)
+	if got := insufficient.Load(); got != concurrentBuyers-initialStock {
+		t.Errorf("got %d insufficient-stock errors, want %d", got, concurrentBuyers-initialStock)
 	}
 
 	final, err := repo.FindByID(ctx, id)

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -2,28 +2,37 @@ package store
 
 const (
 	queryInsert = `
-		INSERT INTO products (id, name, price_minor, currency)
-		VALUES ($1, $2, $3, $4);`
+		INSERT INTO products (id, name, price_minor, currency, stock)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING version;`
 	queryGetByID = `
-		SELECT id, name, price_minor, currency
+		SELECT id, name, price_minor, currency, stock, version
 		FROM products
 		WHERE id = $1;`
 	queryGetAll = `
-		SELECT id, name, price_minor, currency
+		SELECT id, name, price_minor, currency, stock, version
 		FROM products
 		ORDER BY id
 		LIMIT $1;`
 	queryGetAllAfterCursor = `
-		SELECT id, name, price_minor, currency
+		SELECT id, name, price_minor, currency, stock, version
 		FROM products
 		WHERE id > $1
 		ORDER BY id
 		LIMIT $2;`
 	queryUpdate = `
 		UPDATE products
-		SET name = $2, price_minor = $3, currency = $4
-		WHERE id = $1;`
+		SET name = $2, price_minor = $3, currency = $4, version = version + 1
+		WHERE id = $1
+		RETURNING id, name, price_minor, currency, stock, version;`
 	queryDelete = `
 		DELETE FROM products
 		WHERE id = $1;`
+	queryPurchase = `
+		UPDATE products
+		SET stock = stock - $2, version = version + 1
+		WHERE id = $1 AND stock >= $2
+		RETURNING id, name, price_minor, currency, stock, version;`
+	queryProductExists = `
+		SELECT EXISTS(SELECT 1 FROM products WHERE id = $1);`
 )

--- a/internal/transport/grpc/dto.go
+++ b/internal/transport/grpc/dto.go
@@ -7,8 +7,9 @@ import (
 
 func toProto(p domain.Product) *catalogv1.Product {
 	return catalogv1.Product_builder{
-		Id:   p.ID.String(),
-		Name: p.Name,
+		Id:    p.ID.String(),
+		Name:  p.Name,
+		Stock: p.Stock,
 		Price: catalogv1.Money_builder{
 			MinorAmount: p.Price.MinorAmount,
 			Currency:    string(p.Price.Currency),

--- a/internal/transport/grpc/handler.go
+++ b/internal/transport/grpc/handler.go
@@ -18,8 +18,9 @@ type (
 		Create(context.Context, domain.Product) (domain.Product, error)
 		FindByID(context.Context, uuid.UUID) (domain.Product, error)
 		FindAll(context.Context, uuid.NullUUID, int) (domain.ProductPage, error)
-		Update(context.Context, domain.Product) error
+		Update(context.Context, domain.Product) (domain.Product, error)
 		Delete(context.Context, uuid.UUID) error
+		Purchase(context.Context, uuid.UUID, int64) (domain.Product, error)
 	}
 	// Handler adapts the product service to the generated ProductServiceServer.
 	Handler struct {
@@ -37,7 +38,7 @@ func NewHandler(p processor, l *slog.Logger) *Handler {
 func (h *Handler) CreateProduct(
 	ctx context.Context, req *catalogv1.CreateProductRequest,
 ) (*catalogv1.CreateProductResponse, error) {
-	p := domain.Product{Name: req.GetName(), Price: toDomainMoney(req.GetPrice())}
+	p := domain.Product{Name: req.GetName(), Price: toDomainMoney(req.GetPrice()), Stock: req.GetStock()}
 	if err := p.Validate(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -90,10 +91,11 @@ func (h *Handler) UpdateProduct(
 	if err := p.Validate(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	if err := h.processor.Update(ctx, p); err != nil {
+	updated, err := h.processor.Update(ctx, p)
+	if err != nil {
 		return nil, h.toStatus(err, "update product")
 	}
-	return catalogv1.UpdateProductResponse_builder{Product: toProto(p)}.Build(), nil
+	return catalogv1.UpdateProductResponse_builder{Product: toProto(updated)}.Build(), nil
 }
 
 func (h *Handler) DeleteProduct(
@@ -109,6 +111,28 @@ func (h *Handler) DeleteProduct(
 	return catalogv1.DeleteProductResponse_builder{}.Build(), nil
 }
 
+func (h *Handler) PurchaseProduct(
+	ctx context.Context, req *catalogv1.PurchaseProductRequest,
+) (*catalogv1.PurchaseProductResponse, error) {
+	id, err := uuid.Parse(req.GetId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	qty := req.GetQuantity()
+	if !domain.ValidPurchaseQuantity(qty) {
+		return nil, status.Error(codes.InvalidArgument, "quantity must be between 1 and 10000")
+	}
+	p, err := h.processor.Purchase(ctx, id, qty)
+	if err != nil {
+		return nil, h.toStatus(err, "purchase product")
+	}
+	return catalogv1.PurchaseProductResponse_builder{
+		ProductId:      p.ID.String(),
+		Quantity:       qty,
+		RemainingStock: p.Stock,
+	}.Build(), nil
+}
+
 // toStatus maps domain errors to gRPC codes; unknown errors become Internal.
 func (h *Handler) toStatus(err error, op string) error {
 	switch {
@@ -118,6 +142,8 @@ func (h *Handler) toStatus(err error, op string) error {
 		return status.Error(codes.DeadlineExceeded, "deadline exceeded")
 	case errors.Is(err, domain.ErrNotFound):
 		return status.Error(codes.NotFound, "product not found")
+	case errors.Is(err, domain.ErrInsufficientStock):
+		return status.Error(codes.FailedPrecondition, "insufficient stock")
 	case errors.Is(err, domain.ErrUnavailable):
 		return status.Error(codes.Unavailable, "service temporarily unavailable")
 	default:

--- a/internal/transport/grpc/handler_test.go
+++ b/internal/transport/grpc/handler_test.go
@@ -26,7 +26,7 @@ func TestHandler_CreateProduct(t *testing.T) {
 	})
 
 	resp, err := client.CreateProduct(t.Context(), catalogv1.CreateProductRequest_builder{
-		Name: "Test", Price: testMoney(1000),
+		Name: "Test", Price: testMoney(1000), Stock: 5,
 	}.Build())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -36,6 +36,9 @@ func TestHandler_CreateProduct(t *testing.T) {
 	}
 	if got := resp.GetProduct().GetName(); got != "Test" {
 		t.Errorf("got name %q, want %q", got, "Test")
+	}
+	if got := resp.GetProduct().GetStock(); got != 5 {
+		t.Errorf("got stock %d, want 5", got)
 	}
 }
 
@@ -84,7 +87,10 @@ func TestHandler_ListProducts(t *testing.T) {
 func TestHandler_UpdateProduct(t *testing.T) {
 	id := uuid.Must(uuid.NewV7())
 	client := newTestClient(t, stubProcessor{
-		UpdateFn: func(context.Context, domain.Product) error { return nil },
+		UpdateFn: func(_ context.Context, p domain.Product) (domain.Product, error) {
+			p.Stock = 7 // stock comes from the store, not the request
+			return p, nil
+		},
 	})
 
 	resp, err := client.UpdateProduct(t.Context(), catalogv1.UpdateProductRequest_builder{
@@ -95,6 +101,9 @@ func TestHandler_UpdateProduct(t *testing.T) {
 	}
 	if got := resp.GetProduct().GetName(); got != "Updated" {
 		t.Errorf("got name %q, want %q", got, "Updated")
+	}
+	if got := resp.GetProduct().GetStock(); got != 7 {
+		t.Errorf("got stock %d, want 7 (from store, not request)", got)
 	}
 }
 
@@ -108,6 +117,31 @@ func TestHandler_DeleteProduct(t *testing.T) {
 		Id: id.String(),
 	}.Build()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandler_PurchaseProduct(t *testing.T) {
+	id := uuid.Must(uuid.NewV7())
+	client := newTestClient(t, stubProcessor{
+		PurchaseFn: func(_ context.Context, pid uuid.UUID, _ int64) (domain.Product, error) {
+			return domain.Product{ID: pid, Stock: 8}, nil
+		},
+	})
+
+	resp, err := client.PurchaseProduct(t.Context(), catalogv1.PurchaseProductRequest_builder{
+		Id: id.String(), Quantity: 2,
+	}.Build())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := resp.GetProductId(); got != id.String() {
+		t.Errorf("got productId %q, want %q", got, id.String())
+	}
+	if got := resp.GetQuantity(); got != 2 {
+		t.Errorf("got quantity %d, want 2", got)
+	}
+	if got := resp.GetRemainingStock(); got != 8 {
+		t.Errorf("got remainingStock %d, want 8", got)
 	}
 }
 
@@ -152,6 +186,32 @@ func TestHandler_ErrorMapping(t *testing.T) {
 				return err
 			},
 			want: codes.NotFound,
+		},
+		{
+			name: "insufficient stock",
+			proc: stubProcessor{
+				PurchaseFn: func(context.Context, uuid.UUID, int64) (domain.Product, error) {
+					return domain.Product{}, domain.ErrInsufficientStock
+				},
+			},
+			call: func(ctx context.Context, c catalogv1.ProductServiceClient) error {
+				_, err := c.PurchaseProduct(ctx, catalogv1.PurchaseProductRequest_builder{
+					Id: id.String(), Quantity: 2,
+				}.Build())
+				return err
+			},
+			want: codes.FailedPrecondition,
+		},
+		{
+			name: "invalid quantity",
+			proc: stubProcessor{},
+			call: func(ctx context.Context, c catalogv1.ProductServiceClient) error {
+				_, err := c.PurchaseProduct(ctx, catalogv1.PurchaseProductRequest_builder{
+					Id: id.String(), Quantity: 0,
+				}.Build())
+				return err
+			},
+			want: codes.InvalidArgument,
 		},
 		{
 			name: "unavailable",

--- a/internal/transport/grpc/stub_test.go
+++ b/internal/transport/grpc/stub_test.go
@@ -11,8 +11,9 @@ type stubProcessor struct {
 	CreateFn   func(context.Context, domain.Product) (domain.Product, error)
 	FindByIDFn func(context.Context, uuid.UUID) (domain.Product, error)
 	FindAllFn  func(context.Context, uuid.NullUUID, int) (domain.ProductPage, error)
-	UpdateFn   func(context.Context, domain.Product) error
+	UpdateFn   func(context.Context, domain.Product) (domain.Product, error)
 	DeleteFn   func(context.Context, uuid.UUID) error
+	PurchaseFn func(context.Context, uuid.UUID, int64) (domain.Product, error)
 }
 
 func (s stubProcessor) Create(ctx context.Context, p domain.Product) (domain.Product, error) {
@@ -29,10 +30,14 @@ func (s stubProcessor) FindAll(
 	return s.FindAllFn(ctx, cursor, limit)
 }
 
-func (s stubProcessor) Update(ctx context.Context, p domain.Product) error {
+func (s stubProcessor) Update(ctx context.Context, p domain.Product) (domain.Product, error) {
 	return s.UpdateFn(ctx, p)
 }
 
 func (s stubProcessor) Delete(ctx context.Context, id uuid.UUID) error {
 	return s.DeleteFn(ctx, id)
+}
+
+func (s stubProcessor) Purchase(ctx context.Context, id uuid.UUID, qty int64) (domain.Product, error) {
+	return s.PurchaseFn(ctx, id, qty)
 }

--- a/internal/transport/http/codec.go
+++ b/internal/transport/http/codec.go
@@ -12,13 +12,14 @@ import (
 const (
 	MediaTypeJSON = "application/json"
 
-	msgEncodeFailed  = "error encoding data"
-	msgBodyTooLarge  = "request body too large"
-	msgEmptyBody     = "request body must not be empty"
-	msgMalformedJSON = "request body contains malformed JSON"
-	msgInvalidBody   = "invalid request body"
-	msgInternalError = "internal server error"
-	msgUnavailable   = "service temporarily unavailable"
+	msgEncodeFailed    = "error encoding data"
+	msgBodyTooLarge    = "request body too large"
+	msgEmptyBody       = "request body must not be empty"
+	msgMalformedJSON   = "request body contains malformed JSON"
+	msgInvalidBody     = "invalid request body"
+	msgInternalError   = "internal server error"
+	msgUnavailable     = "service temporarily unavailable"
+	msgInvalidQuantity = "quantity must be between 1 and 10000"
 )
 
 type messageResponse struct {

--- a/internal/transport/http/dto.go
+++ b/internal/transport/http/dto.go
@@ -9,6 +9,7 @@ type (
 	productResponse struct {
 		ID    uuid.UUID `json:"id"`
 		Name  string    `json:"name"`
+		Stock int64     `json:"stock"`
 		Price moneyDTO  `json:"price"`
 	}
 	moneyDTO struct {
@@ -19,10 +20,19 @@ type (
 		Items      []productResponse `json:"items"`
 		NextCursor string            `json:"nextCursor,omitempty"`
 	}
+	purchaseResponse struct {
+		ProductID      uuid.UUID `json:"productId"`
+		Quantity       int64     `json:"quantity"`
+		RemainingStock int64     `json:"remainingStock"`
+	}
 )
 
 func toProductResponse(p domain.Product) productResponse {
-	return productResponse{ID: p.ID, Name: p.Name, Price: toMoneyDTO(p.Price)}
+	return productResponse{ID: p.ID, Name: p.Name, Stock: p.Stock, Price: toMoneyDTO(p.Price)}
+}
+
+func toPurchaseResponse(p domain.Product, qty int64) purchaseResponse {
+	return purchaseResponse{ProductID: p.ID, Quantity: qty, RemainingStock: p.Stock}
 }
 
 func toProductsResponse(ps []domain.Product) []productResponse {

--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -18,8 +18,9 @@ type (
 		Create(context.Context, domain.Product) (domain.Product, error)
 		FindByID(context.Context, uuid.UUID) (domain.Product, error)
 		FindAll(context.Context, uuid.NullUUID, int) (domain.ProductPage, error)
-		Update(context.Context, domain.Product) error
+		Update(context.Context, domain.Product) (domain.Product, error)
 		Delete(context.Context, uuid.UUID) error
+		Purchase(context.Context, uuid.UUID, int64) (domain.Product, error)
 	}
 	Handler struct {
 		logger         *slog.Logger
@@ -30,9 +31,17 @@ type (
 		MinorAmount int64           `json:"minorAmount"`
 		Currency    domain.Currency `json:"currency"`
 	}
-	productInput struct {
+	addInput struct {
+		Name  string     `json:"name"`
+		Stock int64      `json:"stock"`
+		Price moneyInput `json:"price"`
+	}
+	updateInput struct {
 		Name  string     `json:"name"`
 		Price moneyInput `json:"price"`
+	}
+	purchaseInput struct {
+		Quantity int64 `json:"quantity"`
 	}
 )
 
@@ -100,14 +109,14 @@ func (h *Handler) Add(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var in productInput
+	var in addInput
 	if err := decodeBody(r.Body, &in); err != nil {
 		h.logger.Warn("decode body failed", slog.Any("error", err))
 		respondDecodeError(w, err)
 		return
 	}
 
-	p := domain.Product{Name: in.Name, Price: toMoney(in.Price)}
+	p := domain.Product{Name: in.Name, Price: toMoney(in.Price), Stock: in.Stock}
 	if err := p.Validate(); err != nil {
 		respondError(w, http.StatusUnprocessableEntity, err.Error())
 		return
@@ -160,7 +169,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var in productInput
+	var in updateInput
 	if err := decodeBody(r.Body, &in); err != nil {
 		h.logger.Warn("decode body failed", slog.Any("error", err))
 		respondDecodeError(w, err)
@@ -176,7 +185,8 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
 	defer cancel()
 
-	if err := h.processor.Update(ctx, p); err != nil {
+	updated, err := h.processor.Update(ctx, p)
+	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			respondError(w, http.StatusNotFound, "unable to update product, which does not exist")
 			return
@@ -187,7 +197,51 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
-	respond(w, http.StatusOK, toProductResponse(p))
+	respond(w, http.StatusOK, toProductResponse(updated))
+}
+
+func (h *Handler) Purchase(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if r.ContentLength == 0 {
+		respondError(w, http.StatusBadRequest, msgEmptyBody)
+		return
+	}
+
+	var in purchaseInput
+	if err := decodeBody(r.Body, &in); err != nil {
+		h.logger.Warn("decode body failed", slog.Any("error", err))
+		respondDecodeError(w, err)
+		return
+	}
+	if !domain.ValidPurchaseQuantity(in.Quantity) {
+		respondError(w, http.StatusUnprocessableEntity, msgInvalidQuantity)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
+	defer cancel()
+
+	p, err := h.processor.Purchase(ctx, id, in.Quantity)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrNotFound):
+			respondError(w, http.StatusNotFound, "product not found")
+		case errors.Is(err, domain.ErrInsufficientStock):
+			respondError(w, http.StatusConflict, "insufficient stock")
+		default:
+			h.respondServerError(
+				w, err, "failed to purchase product",
+				slog.Any("error", err), slog.String("id", id.String()),
+			)
+		}
+		return
+	}
+	respond(w, http.StatusOK, toPurchaseResponse(p, in.Quantity))
 }
 
 // respondServerError maps infrastructure failures to 503 or 500 and logs them.

--- a/internal/transport/http/handler_test.go
+++ b/internal/transport/http/handler_test.go
@@ -260,7 +260,7 @@ func TestAddProduct(t *testing.T) {
 	}{
 		{
 			name: "success",
-			body: productInput{Name: "Car", Price: testMoneyInput(123)},
+			body: addInput{Name: "Car", Stock: 7, Price: testMoneyInput(123)},
 			setupMock: func() {
 				proc.create = func(_ context.Context, p domain.Product) (domain.Product, error) {
 					return p, nil
@@ -288,14 +288,14 @@ func TestAddProduct(t *testing.T) {
 		},
 		{
 			name:           "negative price",
-			body:           productInput{Name: "Car", Price: testMoneyInput(-1)},
+			body:           addInput{Name: "Car", Price: testMoneyInput(-1)},
 			setupMock:      func() {},
 			expectedStatus: http.StatusUnprocessableEntity,
 			expectedMsg:    "the product price must be positive",
 		},
 		{
 			name: "invalid currency",
-			body: productInput{
+			body: addInput{
 				Name:  "Car",
 				Price: moneyInput{MinorAmount: 123, Currency: domain.Currency("XXX")},
 			},
@@ -321,6 +321,12 @@ func TestAddProduct(t *testing.T) {
 				t.Errorf("got status %d, want %d", resp.Code, tt.expectedStatus)
 			}
 
+			if tt.expectedStatus == http.StatusCreated {
+				if p := decodeJSON[productResponse](t, resp.Body); p.Stock != 7 {
+					t.Errorf("got stock %d, want 7", p.Stock)
+				}
+				return
+			}
 			if tt.expectedMsg != "" {
 				e := decodeJSON[messageResponse](t, resp.Body)
 				if e.Message != tt.expectedMsg {
@@ -437,10 +443,11 @@ func TestUpdateProduct(t *testing.T) {
 		{
 			name: "success",
 			id:   uuid.Must(uuid.NewV7()).String(),
-			body: productInput{Name: "Updated", Price: testMoneyInput(9990)},
+			body: updateInput{Name: "Updated", Price: testMoneyInput(9990)},
 			setupMock: func() {
-				proc.update = func(_ context.Context, _ domain.Product) error {
-					return nil
+				proc.update = func(_ context.Context, p domain.Product) (domain.Product, error) {
+					p.Stock = 7 // stock comes from the store, not the request body
+					return p, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
@@ -482,6 +489,102 @@ func TestUpdateProduct(t *testing.T) {
 				if p.Name != tt.expectedName {
 					t.Errorf("got name %q, want %q", p.Name, tt.expectedName)
 				}
+				if p.Stock != 7 {
+					t.Errorf("got stock %d, want 7 (from store, not request)", p.Stock)
+				}
+			}
+		})
+	}
+}
+
+func TestPurchaseProduct(t *testing.T) {
+	mux, proc := setupTest(t)
+
+	id := uuid.Must(uuid.NewV7())
+
+	tests := []struct {
+		name           string
+		quantity       int64
+		setupMock      func()
+		expectedStatus int
+		expectedMsg    string
+	}{
+		{
+			name:     "success",
+			quantity: 2,
+			setupMock: func() {
+				proc.purchase = func(_ context.Context, pid uuid.UUID, _ int64) (domain.Product, error) {
+					return domain.Product{ID: pid, Name: "Car", Price: testMoney(), Stock: 5}, nil
+				}
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "quantity below min",
+			quantity:       0,
+			setupMock:      func() {},
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedMsg:    msgInvalidQuantity,
+		},
+		{
+			name:           "quantity above max",
+			quantity:       10001,
+			setupMock:      func() {},
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedMsg:    msgInvalidQuantity,
+		},
+		{
+			name:     "product not found",
+			quantity: 2,
+			setupMock: func() {
+				proc.purchase = func(_ context.Context, _ uuid.UUID, _ int64) (domain.Product, error) {
+					return domain.Product{}, domain.ErrNotFound
+				}
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedMsg:    "product not found",
+		},
+		{
+			name:     "insufficient stock",
+			quantity: 2,
+			setupMock: func() {
+				proc.purchase = func(_ context.Context, _ uuid.UUID, _ int64) (domain.Product, error) {
+					return domain.Product{}, domain.ErrInsufficientStock
+				}
+			},
+			expectedStatus: http.StatusConflict,
+			expectedMsg:    "insufficient stock",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+			b, err := json.Marshal(purchaseInput{Quantity: tt.quantity})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			req := httptest.NewRequestWithContext(
+				t.Context(), http.MethodPost, "/v1/product/"+id.String()+"/purchase", bytes.NewReader(b),
+			)
+			resp := httptest.NewRecorder()
+			mux.ServeHTTP(resp, req)
+
+			if resp.Code != tt.expectedStatus {
+				t.Errorf("got status %d, want %d", resp.Code, tt.expectedStatus)
+			}
+
+			if tt.expectedStatus == http.StatusOK {
+				pr := decodeJSON[purchaseResponse](t, resp.Body)
+				if pr.ProductID != id || pr.Quantity != 2 || pr.RemainingStock != 5 {
+					t.Errorf("got %+v, want productId=%v quantity=2 remainingStock=5", pr, id)
+				}
+				return
+			}
+			e := decodeJSON[messageResponse](t, resp.Body)
+			if e.Message != tt.expectedMsg {
+				t.Errorf("got msg %q, want %q", e.Message, tt.expectedMsg)
 			}
 		})
 	}

--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -13,6 +13,7 @@ func NewMux(h *Handler) *http.ServeMux {
 	mux.HandleFunc("GET /v1/product", h.Get)
 	mux.HandleFunc("GET /v1/product/{id}", h.GetByID)
 	mux.HandleFunc("DELETE /v1/product/{id}", h.Delete)
+	mux.HandleFunc("POST /v1/product/{id}/purchase", h.Purchase)
 
 	return mux
 }

--- a/internal/transport/http/stub_test.go
+++ b/internal/transport/http/stub_test.go
@@ -11,8 +11,9 @@ type stubProcessor struct {
 	create   func(context.Context, domain.Product) (domain.Product, error)
 	findByID func(context.Context, uuid.UUID) (domain.Product, error)
 	findAll  func(context.Context, uuid.NullUUID, int) (domain.ProductPage, error)
-	update   func(context.Context, domain.Product) error
+	update   func(context.Context, domain.Product) (domain.Product, error)
 	delete   func(context.Context, uuid.UUID) error
+	purchase func(context.Context, uuid.UUID, int64) (domain.Product, error)
 }
 
 func (s *stubProcessor) Create(ctx context.Context, p domain.Product) (domain.Product, error) {
@@ -31,10 +32,14 @@ func (s *stubProcessor) FindAll(ctx context.Context, cursor uuid.NullUUID, limit
 	return s.findAll(ctx, cursor, limit)
 }
 
-func (s *stubProcessor) Update(ctx context.Context, p domain.Product) error {
+func (s *stubProcessor) Update(ctx context.Context, p domain.Product) (domain.Product, error) {
 	return s.update(ctx, p)
 }
 
 func (s *stubProcessor) Delete(ctx context.Context, id uuid.UUID) error {
 	return s.delete(ctx, id)
+}
+
+func (s *stubProcessor) Purchase(ctx context.Context, id uuid.UUID, qty int64) (domain.Product, error) {
+	return s.purchase(ctx, id, qty)
 }

--- a/migrate/migrations/00001_create_products.sql
+++ b/migrate/migrations/00001_create_products.sql
@@ -1,8 +1,10 @@
 -- +goose Up
 CREATE TABLE products (
     id UUID PRIMARY KEY,
-    name VARCHAR(100) NOT NULL,
     price_minor BIGINT NOT NULL CHECK (price_minor > 0),
+    version BIGINT NOT NULL DEFAULT 1,
+    stock INTEGER NOT NULL DEFAULT 0 CHECK (stock >= 0),
+    name VARCHAR(100) NOT NULL,
     -- Keep this list in sync with internal/domain/money.go.
     currency VARCHAR(3) NOT NULL CHECK (currency IN ('PLN', 'EUR', 'USD', 'GBP', 'CHF'))
 );


### PR DESCRIPTION
- add  stock  and  version  columns to  products  table
- optimize database schema column alignment to reduce padding
- extend  Product  domain entity with validation logic
- implement atomic stock-decrement transaction ( Purchase )
- register  /v1/product/{id}/purchase  HTTP endpoint
- add  PurchaseProduct  gRPC RPC method
- map purchase errors to HTTP (404/409/422) and gRPC codes
- write concurrent integration tests verifying the oversell invariant under  -race 
- cover input validation and error mapping in handler unit tests