### PR TITLE
feat: grpc reflection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ GRPC_HOST=
 GRPC_PORT=9090
 GRPC_MAX_REQUEST_BYTES=1048576
 GRPC_REQUEST_TIMEOUT=2s
+# server reflection for grpcurl, dev only, keep off in prod
+GRPC_REFLECTION=true
 
 # Process
 SHUTDOWN_TIMEOUT=10s

--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@
 
 ## General Info
 
-Small REST API built with clean architecture principles.  
+Product catalog API exposed over REST and gRPC.  
+PostgreSQL is the source of truth, with goose migrations embedded in the binary.  
+Product reads use cache-aside Redis, concurrent misses are coalesced with singleflight.  
+Purchase decrements stock atomically with a conditional UPDATE.  
 
 ## Technologies
 
 * Go 1.26
 * PostgreSQL 18.x
-* Redis 8.x
+* Redis 8.8
 
 ## Quickstart
 
@@ -39,66 +42,71 @@ All available variables with their defaults are documented in `.env.example`.
 
 ```bash
 # create a product (stock is optional, defaults to 0)
-curl -s -X POST http://localhost:7000/v1/product \
+curl -s -X POST http://localhost:8080/v1/product \
   -H 'Content-Type: application/json' \
   -d '{"name":"widget","stock":10,"price":{"minorAmount":999,"currency":"PLN"}}'
 
 # get a product by id
-curl -s http://localhost:7000/v1/product/{id}
+curl -s http://localhost:8080/v1/product/{id}
 
 # list products (keyset pagination)
-curl -s 'http://localhost:7000/v1/product?limit=10'
+curl -s 'http://localhost:8080/v1/product?limit=10'
 # next page: pass the nextCursor from the previous response
-curl -s 'http://localhost:7000/v1/product?limit=10&cursor={nextCursor}'
+curl -s 'http://localhost:8080/v1/product?limit=10&cursor={nextCursor}'
 
 # purchase units, decrementing stock atomically
-curl -s -X POST http://localhost:7000/v1/product/{id}/purchase \
+curl -s -X POST http://localhost:8080/v1/product/{id}/purchase \
   -H 'Content-Type: application/json' \
   -d '{"quantity":2}'
 ```
 
-The list endpoint returns `{"items":[...],"nextCursor":"<id>"}`; a missing `nextCursor` means the last page.
+The list endpoint returns `{"items":[...],"nextCursor":"<id>"}`.  
+A missing `nextCursor` means the last page.  
 
-Stock is set at creation and changed only through purchase; `PUT` does not accept a `stock` field.
-Purchase returns `{"productId":"<id>","quantity":2,"remainingStock":8}`; `409` signals insufficient stock.
-
+Stock is set at creation and changed only through purchase.  
+`PUT` does not accept a `stock` field.  
+Purchase returns `{"productId":"<id>","quantity":2,"remainingStock":8}`.  
+A `409 Conflict` signals insufficient stock.  
 See `api.rest` for the full set of example requests.
 
 ## gRPC API
 
 A gRPC transport mirrors the HTTP surface over the same service, on `GRPC_PORT` (default `9090`),
-with a registered gRPC health service. The contract lives in
-`api/proto/catalog/v1/product.proto` (Protobuf edition 2024); code is generated with
-[buf](https://buf.build) into `api/gen` (`make proto`). Reflection is disabled, so
-[grpcurl](https://github.com/fullstorydev/grpcurl) needs the proto:
+with a registered gRPC health service.  
+The contract lives in `api/proto/catalog/v1/product.proto` (Protobuf edition 2024).  
+Code is generated with [buf](https://buf.build) into `api/gen` (`make proto`).
+
+Server reflection is off by default.  
+Set `GRPC_REFLECTION=true` (dev only) and [grpcurl](https://github.com/fullstorydev/grpcurl) discovers the API without the proto:
 
 ```bash
-PROTO="-import-path api/proto -proto catalog/v1/product.proto"
+grpcurl -plaintext localhost:9090 list
+grpcurl -plaintext localhost:9090 describe catalog.v1.ProductService
 
 # create a product (stock is optional, defaults to 0)
-grpcurl -plaintext $PROTO -d '{"name":"widget","stock":10,"price":{"minorAmount":999,"currency":"PLN"}}' \
+grpcurl -plaintext -d '{"name":"widget","stock":10,"price":{"minorAmount":999,"currency":"PLN"}}' \
   localhost:9090 catalog.v1.ProductService/CreateProduct
 
 # get a product by id
-grpcurl -plaintext $PROTO -d '{"id":"<id>"}' \
+grpcurl -plaintext -d '{"id":"<id>"}' \
   localhost:9090 catalog.v1.ProductService/GetProduct
 
 # list products (keyset pagination)
-grpcurl -plaintext $PROTO -d '{"limit":10}' \
+grpcurl -plaintext -d '{"limit":10}' \
   localhost:9090 catalog.v1.ProductService/ListProducts
 
 # purchase units (FAILED_PRECONDITION on insufficient stock)
-grpcurl -plaintext $PROTO -d '{"id":"<id>","quantity":2}' \
+grpcurl -plaintext -d '{"id":"<id>","quantity":2}' \
   localhost:9090 catalog.v1.ProductService/PurchaseProduct
 ```
 
 ## Architecture
 
-`cmd/` → `httpapi` → `service` → `repository`, with `cache` and `entity` as cross-cutting packages.
+`cmd/` → `transport/http` and `transport/grpc` → `service` → `store`, with `domain` and `cache` as cross-cutting packages.
 
 ## Migrations
 
-Schema changes live in `internal/migrate/migrations/` and are bundled into the binary via `embed.FS`.  
+Schema changes live in `migrate/migrations/` and are bundled into the binary via `embed.FS`.  
 The `cmd/migrate` CLI applies them using [goose](https://github.com/pressly/goose).
 
 ```bash

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,8 +105,14 @@ func run(logger *slog.Logger, cfg config.Config) error {
 	)
 
 	grpcSrv := grpcsrv.NewServer(
-		cfg.GRPC.Address(), cfg.GRPC.RequestTimeout,
-		int(cfg.GRPC.MaxRequestBytes), cfg.ShutdownTimeout, srv, logger,
+		grpcsrv.ServerCfg{
+			Addr:            cfg.GRPC.Address(),
+			RequestTimeout:  cfg.GRPC.RequestTimeout,
+			MaxRequestBytes: int(cfg.GRPC.MaxRequestBytes),
+			ShutdownTimeout: cfg.ShutdownTimeout,
+			Reflection:      cfg.GRPC.Reflection,
+		},
+		srv, logger,
 	)
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type (
 		Port            int           `env:"GRPC_PORT" envDefault:"9090"`
 		RequestTimeout  time.Duration `env:"GRPC_REQUEST_TIMEOUT" envDefault:"2s"`
 		MaxRequestBytes int64         `env:"GRPC_MAX_REQUEST_BYTES" envDefault:"1048576"` // 1 MiB
+		Reflection      bool          `env:"GRPC_REFLECTION" envDefault:"false"`
 	}
 	Service struct {
 		LoadTimeout time.Duration `env:"SERVICE_LOAD_TIMEOUT" envDefault:"1s"`

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -12,55 +12,45 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
-// Server serves the gRPC API over the product service.
-type Server struct {
-	addr            string
-	requestTimeout  time.Duration
-	maxRequestBytes int
-	shutdownTimeout time.Duration
-	svc             processor
-	log             *slog.Logger
-}
+type (
+	// ServerCfg carries the gRPC server settings.
+	ServerCfg struct {
+		Addr            string
+		RequestTimeout  time.Duration
+		MaxRequestBytes int
+		ShutdownTimeout time.Duration
+		// Reflection enables server reflection for CLI tooling; dev only.
+		Reflection bool
+	}
+	// Server serves the gRPC API over the product service.
+	Server struct {
+		cfg ServerCfg
+		svc processor
+		log *slog.Logger
+	}
+)
 
 // NewServer configures a gRPC server for svc.
-func NewServer(
-	addr string,
-	requestTimeout time.Duration,
-	maxRequestBytes int,
-	shutdownTimeout time.Duration,
-	svc processor,
-	log *slog.Logger,
-) *Server {
-	return new(Server{
-		addr:            addr,
-		requestTimeout:  requestTimeout,
-		maxRequestBytes: maxRequestBytes,
-		shutdownTimeout: shutdownTimeout,
-		svc:             svc,
-		log:             log,
-	})
+func NewServer(cfg ServerCfg, svc processor, log *slog.Logger) *Server {
+	return new(Server{cfg: cfg, svc: svc, log: log})
 }
 
 // Run serves until ctx is cancelled, then stops gracefully.
 func (s *Server) Run(ctx context.Context) error {
 	var lc net.ListenConfig
-	lis, err := lc.Listen(ctx, "tcp", s.addr)
+	lis, err := lc.Listen(ctx, "tcp", s.cfg.Addr)
 	if err != nil {
 		return fmt.Errorf("grpc listen: %w", err)
 	}
 
-	srv := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(logging(s.log), recovery(s.log), timeout(s.requestTimeout)),
-		grpc.MaxRecvMsgSize(s.maxRequestBytes),
-	)
-	catalogv1.RegisterProductServiceServer(srv, NewHandler(s.svc, s.log))
-	healthgrpc.RegisterHealthServer(srv, health.NewServer())
+	srv := s.newServer()
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		s.log.Info("starting grpc server", slog.String("address", s.addr))
+		s.log.Info("starting grpc server", slog.String("address", s.cfg.Addr))
 		if err := srv.Serve(lis); err != nil {
 			return fmt.Errorf("grpc serve failed: %w", err)
 		}
@@ -68,12 +58,27 @@ func (s *Server) Run(ctx context.Context) error {
 	})
 	eg.Go(func() error {
 		<-ctx.Done()
-		s.log.Info("shutting down grpc server", slog.String("address", s.addr))
-		force := time.AfterFunc(s.shutdownTimeout, srv.Stop)
+		s.log.Info("shutting down grpc server", slog.String("address", s.cfg.Addr))
+		force := time.AfterFunc(s.cfg.ShutdownTimeout, srv.Stop)
 		defer force.Stop()
 		srv.GracefulStop()
 		return nil
 	})
 
 	return eg.Wait()
+}
+
+// newServer assembles the grpc.Server with interceptors and registered services.
+func (s *Server) newServer() *grpc.Server {
+	srv := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(logging(s.log), recovery(s.log), timeout(s.cfg.RequestTimeout)),
+		grpc.MaxRecvMsgSize(s.cfg.MaxRequestBytes),
+	)
+	catalogv1.RegisterProductServiceServer(srv, NewHandler(s.svc, s.log))
+	healthgrpc.RegisterHealthServer(srv, health.NewServer())
+	if s.cfg.Reflection {
+		reflection.Register(srv)
+		s.log.Info("grpc reflection enabled")
+	}
+	return srv
 }

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -22,7 +22,7 @@ type (
 		RequestTimeout  time.Duration
 		MaxRequestBytes int
 		ShutdownTimeout time.Duration
-		// Reflection enables server reflection for CLI tooling; dev only.
+		// Reflection enables server reflection for CLI tooling in dev, keep off in prod.
 		Reflection bool
 	}
 	// Server serves the gRPC API over the product service.

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -1,0 +1,33 @@
+package grpc
+
+import (
+	"log/slog"
+	"testing"
+)
+
+const reflectionService = "grpc.reflection.v1.ServerReflection"
+
+func TestServer_Reflection(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			name:    "enabled registers reflection service",
+			enabled: true,
+		},
+		{
+			name:    "disabled omits reflection service",
+			enabled: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewServer(ServerCfg{Reflection: tc.enabled}, stubProcessor{}, slog.New(slog.DiscardHandler))
+			_, got := s.newServer().GetServiceInfo()[reflectionService]
+			if got != tc.enabled {
+				t.Errorf("reflection service registered = %v, want %v", got, tc.enabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- opt-in gRPC server reflection behind `GRPC_REFLECTION` (default `false`, dev only) 
- grpcurl works without proto files now
- gRPC server settings collapsed into `ServerCfg`, mirroring the HTTP transport
- test: reflection service registered only when enabled
- README: grpcurl examples use reflection, fixed stale ports (7000→8080), architecture packages and migrations path